### PR TITLE
bound containerfilter

### DIFF
--- a/laboratory/api-src/org/labkey/api/laboratory/QueryCountNavItem.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/QueryCountNavItem.java
@@ -56,8 +56,8 @@ public class QueryCountNavItem extends AbstractQueryNavItem implements SummaryNa
     {
         SimpleFilter filter = new SimpleFilter();
 
-        if (ti.getColumn("container") != null && !(ti.supportsContainerFilter() && ContainerFilter.CURRENT.equals(ti.getContainerFilter())))
-            filter.addClause(ContainerFilter.CURRENT.createFilterClause(ti.getSchema(), FieldKey.fromString("container"), c));
+        if (ti.getColumn("container") != null && !(ti.supportsContainerFilter() && ContainerFilter.current(c).equals(ti.getContainerFilter())))
+            filter.addClause(ContainerFilter.current(c).createFilterClause(ti.getSchema(), FieldKey.fromString("container")));
 
         if (_filter != null)
         {

--- a/laboratory/src/org/labkey/laboratory/query/LaboratoryTableCustomizer.java
+++ b/laboratory/src/org/labkey/laboratory/query/LaboratoryTableCustomizer.java
@@ -973,7 +973,7 @@ public class LaboratoryTableCustomizer implements TableCustomizer
         {
             Container c = ti.getUserSchema().getContainer();
             c = c.isWorkbook() ? c.getParent() : c;
-            SQLFragment containerSql = ContainerFilter.CURRENT.getSQLFragment(LaboratorySchema.getInstance().getSchema(), new SQLFragment(ti.getContainerFieldKey().toString()), c);
+            SQLFragment containerSql = ContainerFilter.current(c).getSQLFragment(LaboratorySchema.getInstance().getSchema(), new SQLFragment(ti.getContainerFieldKey().toString()));
 
             SQLFragment sql = new SQLFragment("(SELECT count(*) as _expr FROM laboratory.samples s WHERE " +
                     " (s.").append(containerSql).append(")" +


### PR DESCRIPTION
#### Rationale
ContainerFilter is associated with a container at construction time.
Tables are constructed in the context of a specific container/user, the CF should also be specified and fixed at construction time as well.