### PR TITLE
Update api and internal packages to gradle 7-compatible configurations

### DIFF
--- a/LDK/build.gradle
+++ b/LDK/build.gradle
@@ -1,6 +1,9 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
 
 dependencies {
+   apiImplementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+   implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"), depProjectConfig: 'apiJarFile')
 


### PR DESCRIPTION
#### Rationale
When updating the api and internal modules to remove use of the deprecated compile configuration, we expose some missing dependency declarations for other modules.  Previously, these dependencies were leaking through from the api module, so we need to declare explicit dependencies when they are not actually a result of reliance on api.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1247

#### Changes
* add dependency on jakarta.mail