### PR TITLE
Delete laboratory.workbooks reference on workbook container delete

### DIFF
--- a/laboratory/src/org/labkey/laboratory/LaboratoryContainerListener.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryContainerListener.java
@@ -122,11 +122,10 @@ public class LaboratoryContainerListener extends SimpleModuleContainerListener
     {
         if (table.getName().equalsIgnoreCase(LaboratorySchema.TABLE_WORKBOOKS))
         {
-            if (!c.isWorkbook())
-            {
-                SQLFragment sql = new SQLFragment("DELETE FROM laboratory.workbooks WHERE " + LaboratoryWorkbooksTable.PARENT_COL + " = ?", c.getId());
-                new SqlExecutor(table.getSchema()).execute(sql);
-            }
+            SQLFragment sql = new SQLFragment("DELETE FROM laboratory.workbooks WHERE " +
+                    (c.isWorkbook() ? LaboratoryWorkbooksTable.WORKBOOK_COL : LaboratoryWorkbooksTable.PARENT_COL) +
+                    " = ?", c.getId());
+            new SqlExecutor(table.getSchema()).execute(sql);
         }
         else
         {


### PR DESCRIPTION
#### Rationale
DatabaseDiagnosticsTest is failing due to orphaned laboratory.workbooks rows that are missing their core.container row. A hard FK might be useful here, but it's possible that it would need to do a cascading delete of existing orphaned rows so keeping it simple for now.

#### Changes
* Delete for workbook containers as well as parent containers