### PR TITLE
Add missing dependency on opencsv

### DIFF
--- a/laboratory/build.gradle
+++ b/laboratory/build.gradle
@@ -3,6 +3,6 @@ import org.labkey.gradle.util.BuildUtils;
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
-
+    apiImplementation "net.sf.opencsv:opencsv:${opencsvVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }


### PR DESCRIPTION
#### Rationale
With version 1.4.0 of the labkey-client-api, we will convert the dependencies on opencsv and httpmime from api dependencies to implementation dependencies since they are not actually a part of the api for this jar file.  Since both of these dependencies are included in the api module transitively, we compromise a bit and do not include them in the `jars.txt` for each individual module.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/14

#### Changes
* Add explicit dependencies where missing