### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/laboratory/build.gradle
+++ b/laboratory/build.gradle
@@ -4,5 +4,6 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "apiJarFile")
     apiImplementation "net.sf.opencsv:opencsv:${opencsvVersion}"
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
 }


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

#### Changes
* Add missing module dependencies
