### PR TITLE
Ignore mutating sql warning while running LabSummaryNotification

### DIFF
--- a/LDK/src/org/labkey/ldk/notification/SiteSummaryNotification.java
+++ b/LDK/src/org/labkey/ldk/notification/SiteSummaryNotification.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.audit.AuditLogService;
 import org.labkey.api.audit.AuditTypeProvider;
 import org.labkey.api.data.CompareType;
@@ -168,7 +169,12 @@ public class SiteSummaryNotification implements Notification
         newValues.put(lastSave, String.valueOf(new Date().getTime()));
         map.putAll(newValues);
 
-        map.save();
+        // this is recording when the report was last run, which is similar to audit logging and similar activities
+        // that we are comfortable treating as non-mutating.
+        try (var ignored = SpringActionController.ignoreSqlUpdates())
+        {
+            map.save();
+        }
     }
 
     @Override

--- a/laboratory/src/org/labkey/laboratory/notification/LabSummaryNotification.java
+++ b/laboratory/src/org/labkey/laboratory/notification/LabSummaryNotification.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
@@ -116,7 +117,12 @@ public class LabSummaryNotification implements Notification
         newValues.put(lastSave, String.valueOf(new Date().getTime()));
         map.putAll(newValues);
 
-        map.save();
+        // this is recording when the report was last run, which is similar to audit logging and similar activities
+        // that we are comfortable treating as non-mutating.
+        try (var ignored = SpringActionController.ignoreSqlUpdates())
+        {
+            map.save();
+        }
     }
 
     private String getPctChange(Long oldVal, Long newVal, double threshold)


### PR DESCRIPTION
#### Rationale
LabSummaryNotification is called from a get action but also saves (mutates) the database with information about when this report was last run. ONPRC_EHRTest which tests this notification started failing due to mutating sql exception from RunNotification Get action. This PR fixes the test failure by ignoring that exception.

