### PR TITLE
Fix project entry field

### DIFF
--- a/LDK/resources/web/LDK/plugin/UserEditableCombo.js
+++ b/LDK/resources/web/LDK/plugin/UserEditableCombo.js
@@ -81,9 +81,11 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
             },
 
             setValue: function(val){
-                this.addValueIfNeeded(val);
+                if (val) {
+                    this.addValueIfNeeded(val);
 
-                this.callOverridden(arguments);
+                    this.callOverridden(arguments);
+                }
             }
         });
 


### PR DESCRIPTION
#### Rationale
When an animal Id is entered into a data entry form grid row, the store gets populated with animal's project and setValue sets the value of project field with first value in the list which is correct, the subsequent addition of rows adds the projects in the store list and the value of next animal with different project is not first in the list and hence incorrect. This PR fixes the aforementioned problem and also fixes the problem of projects not getting populated from second row onwards with tabbing. 

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/158

#### Changes
* do not set null values
