### PR TITLE
Avoid 'JavaScriptException' from WebDriver.getPageSource

### DIFF
--- a/LDK/test/src/org/labkey/test/util/external/labModules/LabModuleHelper.java
+++ b/LDK/test/src/org/labkey/test/util/external/labModules/LabModuleHelper.java
@@ -223,8 +223,9 @@ public class LabModuleHelper
 
     public String getPageText()
     {
+        String text = _test.getHtmlSource();
         //the browser converts line breaks to spaces.  this is a hack to get them back
-        String text = _test.getDriver().getPageSource().replaceAll("<[^>]+>|&[^;]+;", "");
+        text = text.replaceAll("<[^>]+>|&[^;]+;", "");
         text = text.replaceAll(" {2,}", " ");
         text = text.replaceAll(", ", ",\n").replaceAll("] ", "]\n");
         return text;


### PR DESCRIPTION
#### Rationale
`WebDriver.getPageSource` might throw a `JavaScriptException` if the page hasn't fully loaded yet.
https://www.labkey.org/ONPRC/Support%20Tickets/issues-resolve.view?issueId=43210

#### Changes
* Update `LabModuleTest.getPageTest` to use `WebDriverWrapper.getHtmlSource`
