### PR TITLE
Case insensitive animal history search

### DIFF
--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -200,25 +200,27 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
 
                 if (subjIndex !== -1) {
                     this.notFound.splice(subjIndex, 1);
-                    if (this.caseInsensitive) // Ensure case mismatch corrected
-                        this.subjects.splice(subjIndex, 1, row[this.aliasTable.aliasColumn]);
+                }
+
+                var index = this.subjects.indexOf(row[this.aliasTable.aliasColumn]);
+                if (index === -1 && this.caseInsensitive) {
+                    for (var i = 0; i < this.subjects.length; i++) {
+                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.subjects[i].toLowerCase()) {
+                            index = i;
+                            break;
+                        }
+                    }
+                }
+
+                if (index !== -1) {
+                    this.subjects.splice(index, 1, row[this.aliasTable.idColumn]);
                 }
 
                 // Resolve aliases
                 if (row[this.aliasTable.idColumn] !== row[this.aliasTable.aliasColumn]) {
-                    var index = this.subjects.indexOf(row[this.aliasTable.aliasColumn]);
-                    if (index === -1 && this.caseInsensitive) {
-                        for (var i = 0; i < this.subjects.length; i++) {
-                            if (row[this.aliasTable.aliasColumn].toLowerCase() === this.subjects[i].toLowerCase()) {
-                                index = i;
-                                break;
-                            }
-                        }
-                    }
 
                     if (index !== -1) {
                         this.aliases[row[this.aliasTable.aliasColumn]] = [row[this.aliasTable.idColumn]];
-                        this.subjects.splice(index, 1, row[this.aliasTable.idColumn]);
                     }
                     // In case an alias matches multiple ID's
                     else {

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -191,7 +191,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 var subjIndex = this.notFound.indexOf(row[this.aliasTable.aliasColumn]);
                 if (subjIndex === -1 && this.caseInsensitive) {
                     for (var i = 0; i < this.notFound.length; i++) {
-                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.notFound[i].toLowerCase()) {
+                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.notFound[i].toString().toLowerCase()) {
                             subjIndex = i;
                             break;
                         }
@@ -205,7 +205,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 var index = this.subjects.indexOf(row[this.aliasTable.aliasColumn]);
                 if (index === -1 && this.caseInsensitive) {
                     for (var i = 0; i < this.subjects.length; i++) {
-                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.subjects[i].toLowerCase()) {
+                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.subjects[i].toString().toLowerCase()) {
                             index = i;
                             break;
                         }
@@ -239,7 +239,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 var idIndex = this.notFound.indexOf(row[this.aliasTable.idColumn]);
                 if (idIndex === -1 && this.caseInsensitive) {
                     for (var i = 0; i < this.notFound.length; i++) {
-                        if (row[this.aliasTable.idColumn].toLowerCase() === this.notFound[i].toLowerCase()) {
+                        if (row[this.aliasTable.idColumn].toLowerCase() === this.notFound[i].toString().toLowerCase()) {
                             idIndex = i;
                             break;
                         }
@@ -249,7 +249,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 // TODO: Update this and LDK.Utils.splitIds when the case sensitive cache issues are fixed
                 if (idIndex == -1) {
                     for (var nfIndex = 0; nfIndex < this.notFound.length; nfIndex++) {
-                        if (this.notFound[nfIndex].toUpperCase() == row[this.aliasTable.idColumn]) {
+                        if (this.notFound[nfIndex].toString().toUpperCase() == row[this.aliasTable.idColumn]) {
                             idIndex = nfIndex;
                             break;
                         }

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -156,7 +156,9 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
     aliasTableConfig: function (subjectArray) {
         this.aliasTable.scope = this;
 
-        // Use contains filter to ensure case insensitivity across dbs
+        // When caseInsensitive is true, use contains filter to ensure case insensitivity across dbs. This will return more
+        // results than necessary in some cases, however those results are filtered to match the user input and non-matching
+        // results are not used.
         var filterType = this.caseInsensitive ? LABKEY.Filter.Types.CONTAINS_ONE_OF : LABKEY.Filter.Types.EQUALS_ONE_OF;
         this.aliasTable.filterArray = [LABKEY.Filter.create('alias', subjectArray.join(';'), filterType)];
         this.aliasTable.columns = this.aliasTable.idColumn + (Ext4.isDefined(this.aliasTable.aliasColumn) ? ',' + this.aliasTable.aliasColumn : '');

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -9,6 +9,11 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
 
     nounSingular: 'Subject',
 
+    // This flag updates alias/Id db query to use a case insensitive LK filter (CONTAINS). The
+    // results are processed after to do case insensitive matches on the results with the user entered Ids.
+    // This is primarily for use when an alias table is set for the filter.
+    caseInsensitive: false,
+
     subjects: [],
     notFound: [],
     aliases: {},

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -185,9 +185,12 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 // Remove from notFound array if found
                 var subjIndex = this.notFound.indexOf(row[this.aliasTable.aliasColumn]);
                 if (subjIndex === -1 && this.caseInsensitive) {
-                    subjIndex = this.notFound.findIndex(nf => {
-                        return row[this.aliasTable.aliasColumn].toLowerCase() === nf.toLowerCase()
-                    });
+                    for (var i = 0; i < this.notFound.length; i++) {
+                        if (row[this.aliasTable.aliasColumn].toLowerCase() === this.notFound[i].toLowerCase()) {
+                            subjIndex = i;
+                            break;
+                        }
+                    }
                 }
 
                 if (subjIndex !== -1) {
@@ -200,9 +203,12 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 if (row[this.aliasTable.idColumn] !== row[this.aliasTable.aliasColumn]) {
                     var index = this.subjects.indexOf(row[this.aliasTable.aliasColumn]);
                     if (index === -1 && this.caseInsensitive) {
-                        index = this.subjects.findIndex(subj => {
-                            return row[this.aliasTable.aliasColumn].toLowerCase() === subj.toLowerCase()
-                        });
+                        for (var i = 0; i < this.subjects.length; i++) {
+                            if (row[this.aliasTable.aliasColumn].toLowerCase() === this.subjects[i].toLowerCase()) {
+                                index = i;
+                                break;
+                            }
+                        }
                     }
 
                     if (index !== -1) {
@@ -225,9 +231,12 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
                 // Remove from notFound array if found
                 var idIndex = this.notFound.indexOf(row[this.aliasTable.idColumn]);
                 if (idIndex === -1 && this.caseInsensitive) {
-                    idIndex = this.notFound.findIndex(nf => {
-                        return row[this.aliasTable.idColumn].toLowerCase() == nf.toLowerCase()
-                    });
+                    for (var i = 0; i < this.notFound.length; i++) {
+                        if (row[this.aliasTable.idColumn].toLowerCase() === this.notFound[i].toLowerCase()) {
+                            idIndex = i;
+                            break;
+                        }
+                    }
                 }
 
                 // TODO: Update this and LDK.Utils.splitIds when the case sensitive cache issues are fixed


### PR DESCRIPTION
#### Rationale
Optional case insensitive animal history search.  Opt-in in case some PRC's don't want this behavior.  This only does case insensitive search of animal Ids so there shouldn't be any issues with demographics caches.

#### Related Pull Requests
* https://github.com/LabKey/nircEHRModules/pull/102
* https://github.com/LabKey/snprcEHRModules/pull/407

#### Changes
* If caseInsensitive is true, use CONTAINS filter when querying for valid animal Ids which is case insensitive for PG (MSSQL always case insensitive). Then do lowercase match on Ids and possible aliases. 
