### PR TITLE
Ticket 45210: Fall back quietly on demographics sources via linked schema

### DIFF
--- a/laboratory/src/org/labkey/laboratory/AdditionalDataSource.java
+++ b/laboratory/src/org/labkey/laboratory/AdditionalDataSource.java
@@ -1,8 +1,8 @@
 package org.labkey.laboratory;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -46,7 +46,7 @@ public class AdditionalDataSource extends AbstractDataSource
         return new AdditionalDataSource(cat, label, containerId, schemaName, queryName, reportCategory, importIntoWorkbooks, subjectFieldKey, sampleDateFieldKey);
     }
 
-    public static AdditionalDataSource getFromPropertyManager(Container c, User u, String key, String value) throws IllegalArgumentException
+    public static @Nullable AdditionalDataSource getFromPropertyManager(Container c, User u, String key, String value) throws IllegalArgumentException
     {
         if (value == null)
             return null;

--- a/laboratory/src/org/labkey/laboratory/DemographicsSource.java
+++ b/laboratory/src/org/labkey/laboratory/DemographicsSource.java
@@ -44,10 +44,12 @@ public class DemographicsSource extends AbstractDataSource
         return new DemographicsSource(label, containerId, schemaName, queryName, targetColumn);
     }
 
-    public static DemographicsSource getFromPropertyManager(Container c, User u, String key, String value) throws IllegalArgumentException
+    public static @Nullable DemographicsSource getFromPropertyManager(Container c, User u, String key, String value) throws IllegalArgumentException
     {
         if (value == null)
+        {
             return null;
+        }
 
         try
         {

--- a/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
@@ -431,11 +431,19 @@ public class LaboratoryServiceImpl extends LaboratoryService
                 set = new HashSet<>();
 
             AdditionalDataSource source = AdditionalDataSource.getFromPropertyManager(c, u, entry.getKey(), entry.getValue());
-            if (source != null)
-                set.add(source);
+            if (source == null)
+            {
+                continue;
+            }
 
-            if (set.size() > 0)
-                map.put(c, set);
+            Container targetContainer = source.getTargetContainer(c);
+            if (targetContainer == null || !targetContainer.hasPermission(u, ReadPermission.class))
+            {
+                continue;
+            }
+
+            set.add(source);
+            map.put(c, set);
         }
 
         return Collections.unmodifiableMap(map);
@@ -457,11 +465,19 @@ public class LaboratoryServiceImpl extends LaboratoryService
                 set = new HashSet<>();
 
             DemographicsSource source = DemographicsSource.getFromPropertyManager(c, u, entry.getKey(), entry.getValue());
-            if (source != null)
-                set.add(source);
+            if (source == null)
+            {
+                continue;
+            }
 
-            if (set.size() > 0)
-                map.put(c, set);
+            Container targetContainer = source.getTargetContainer(c);
+            if (targetContainer == null || !targetContainer.hasPermission(u, ReadPermission.class))
+            {
+                continue;
+            }
+
+            set.add(source);
+            map.put(c, set);
         }
 
         return Collections.unmodifiableMap(map);


### PR DESCRIPTION
#### Rationale
Demographics sources managed by the Laboratory module may span multiple containers. New linked schema behavior blocks containers other than the linked schema's source container. This results in noisy ERROR logging when the lookup isn't strictly needed for ONPRC scenarios.

#### Changes
* Don't log ERRORs and stack traces when a demographics source isn't available