### PR TITLE
Clean up query validation warnings. Mostly trailing commas

### DIFF
--- a/LDK/resources/queries/core/SiteUsageByGroup.sql
+++ b/LDK/resources/queries/core/SiteUsageByGroup.sql
@@ -18,7 +18,7 @@ PARAMETERS(MinDate TIMESTAMP)
 SELECT
 
 g.GroupName,
-count(*) AS Visits,
+count(*) AS Visits
 
 FROM core.SiteUsagePerGroup g
 WHERE cast(g.date as date) >= cast(MinDate as date)

--- a/LDK/resources/queries/core/SiteUsagePerGroup.sql
+++ b/LDK/resources/queries/core/SiteUsagePerGroup.sql
@@ -18,8 +18,7 @@ SELECT
 m.UserId,
 g.Name AS GroupName,
 a.Date,
-a.EventType,
---a.comment,
+a.EventType
 
 FROM core.groups g
 

--- a/LDK/resources/queries/ldk/dateRange.sql
+++ b/LDK/resources/queries/ldk/dateRange.sql
@@ -18,7 +18,7 @@ cast(EndDate as TIMESTAMP) as endDate @hidden
 
 FROM (SELECT
 
-timestampadd('SQL_TSI_DAY', i.value, CAST(COALESCE(StartDate, curdate()) AS TIMESTAMP)) as date,
+timestampadd('SQL_TSI_DAY', i.value, CAST(COALESCE(StartDate, curdate()) AS TIMESTAMP)) as date
 
 FROM ldk.integers i
 

--- a/laboratory/resources/queries/laboratory/96well_plate.sql
+++ b/laboratory/resources/queries/laboratory/96well_plate.sql
@@ -1,7 +1,7 @@
 SELECT
 well_96 as well,
 addressbyrow_96 as addressByRow,
-addressbycolumn_96 as addressByColumn,
+addressbycolumn_96 as addressByColumn
 
 FROM laboratory.well_layout p
 WHERE p.plate = 1


### PR DESCRIPTION
#### Rationale
These syntax warnings aren't causing any direct problems but they do clutter up the results of query validation

#### Changes
* Address warnings by trimming extraneous commas