### PR TITLE
Ticket 45210: Fall back quietly when failing to add demographics source

### DIFF
--- a/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
@@ -387,7 +387,7 @@ public class LaboratoryServiceImpl extends LaboratoryService
             }
             catch (IllegalArgumentException e)
             {
-                _log.error("Invalid stored demographics source from container: " + c.getPath(), e);
+                _log.debug("Invalid stored demographics source from container: " + c.getPath(), e);
             }
         }
 


### PR DESCRIPTION
#### Rationale
The previous attempt to quiet logging about failing to resolve demographics sources (in this case, because of linked schema permission changes), https://github.com/LabKey/LabDevKitModules/pull/114, either focused on the wrong spot or there's another codepath that we didn't catch.

Example logging from production that's filling the log files:

```
java.lang.IllegalArgumentException: Unable to create table for query: Demographics
	at org.labkey.laboratory.DemographicsSource.validateKey(DemographicsSource.java:146) ~[laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.DemographicsSource.getFromPropertyManager(DemographicsSource.java:63) ~[laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.LaboratoryServiceImpl.getDemographicsSources(LaboratoryServiceImpl.java:384) [laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.query.LaboratoryTableCustomizer.appendDemographicsCols(LaboratoryTableCustomizer.java:265) [laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.query.LaboratoryTableCustomizer.appendCalculatedCols(LaboratoryTableCustomizer.java:257) [laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.query.DefaultAssayCustomizer.customizeDataTable(DefaultAssayCustomizer.java:203) [laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.query.DefaultAssayCustomizer.customizeAssayTable(DefaultAssayCustomizer.java:54) [laboratory-22.3-SNAPSHOT.jar:?]
	at org.labkey.laboratory.query.DefaultAssayCustomizer.customize(DefaultAssayCustomizer.java:36) [laboratory-22.3-SNAPSHOT.jar:?]
```

#### Changes
* Reduce already caught exception logging to debug level. This will keep it from spamming the logs but still let admins opt-in by changing the log level for LaboratoryServiceImpl via the Admin Console for troubleshooting.