### PR TITLE
Delete jars.txt with no jars and ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.gradle
 /intellijBuild
+*/resources/credits/dependencies.txt
+*/resources/credits/jars.txt

--- a/LDK/resources/credits/jars.txt
+++ b/LDK/resources/credits/jars.txt
@@ -1,3 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-{table}


### PR DESCRIPTION
#### Rationale
We're getting rid of manually generated jars.txt files. Especially those with no content.
