### PR TITLE
Tabbed panel case insensitive top level option

### DIFF
--- a/LDK/resources/web/LDK/Utils.js
+++ b/LDK/resources/web/LDK/Utils.js
@@ -538,7 +538,7 @@ LDK.Utils = new function(){
             window.location = LABKEY.ActionURL.buildURL('ldk', 'updateQuery', null, params);
         },
 
-        splitIds: function(subjectArray, unsorted, preserveDuplicates){
+        splitIds: function(subjectArray, unsorted, preserveDuplicates, preserveCase){
             if (!subjectArray){
                 return [];
             }
@@ -546,7 +546,8 @@ LDK.Utils = new function(){
             subjectArray = Ext4.String.trim(subjectArray);
             subjectArray = subjectArray.replace(/[\s,;]+/g, ';');
             subjectArray = subjectArray.replace(/(^;|;$)/g, '');
-            subjectArray = subjectArray.toLowerCase();
+            if (!preserveCase)
+                subjectArray = subjectArray.toLowerCase();
 
             if (subjectArray){
                 subjectArray = subjectArray.split(';');

--- a/LDK/resources/web/LDK/panel/MultiSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/MultiSubjectFilterType.js
@@ -100,7 +100,7 @@ Ext4.define('LDK.panel.MultiSubjectFilterType', {
     },
 
     addId: function (callback, panel) {
-        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue());
+        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue(), false, false, this.caseInsensitive);
 
         if (subjectArray.length > 0) {
             subjectArray = Ext4.unique(subjectArray);
@@ -148,7 +148,7 @@ Ext4.define('LDK.panel.MultiSubjectFilterType', {
         //we clean up, combine, then split the subjectBox and subject inputs
         var subjectArray = this.subjects;
         if (subjectArray.length == 0)
-            subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue());
+            subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue(), false, false, this.caseInsensitive);
 
         if (existing)
             subjectArray = subjectArray.concat(existing);
@@ -187,7 +187,7 @@ Ext4.define('LDK.panel.MultiSubjectFilterType', {
     },
 
     loadReport: function (tab, callback, panel, forceRefresh) {
-        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue());
+        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue(), false, false, this.caseInsensitive);
 
         if(subjectArray.length > 0) {
             this.addId(function(){

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -59,7 +59,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
 
     handleFilters: function (tab, filters) {
         var filterArray = {
-            subjects: LDK.Utils.splitIds(this.down('#subjArea').getValue()),
+            subjects: LDK.Utils.splitIds(this.down('#subjArea').getValue(), false, false, this.caseInsensitive),
             removable: [],
             nonRemovable: []
         };
@@ -122,7 +122,7 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
     },
     
     loadReport: function(tab, callback, panel, forceRefresh){
-        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue());
+        var subjectArray = LDK.Utils.splitIds(this.down('#subjArea').getValue(), false, false, this.caseInsensitive);
 
         if (subjectArray.length > 0){
             subjectArray = Ext4.unique(subjectArray);

--- a/LDK/resources/web/LDK/panel/TabbedReportPanel.js
+++ b/LDK/resources/web/LDK/panel/TabbedReportPanel.js
@@ -1015,6 +1015,7 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
             var cfg = Ext4.apply({}, filterType);
             cfg.tabbedReportPanel = this;
             cfg.filterContext = this.getFilterContext();
+            cfg.caseInsensitive = this.caseInsensitive;
 
             if (this.activeFilterType){
                 this.activeFilterType.prepareRemove();

--- a/LDK/resources/web/LDK/panel/TabbedReportPanel.js
+++ b/LDK/resources/web/LDK/panel/TabbedReportPanel.js
@@ -28,6 +28,9 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
     autoLoadDefaultTab: false,
     clearBetweenClicks: true,
 
+    // Passed to filters implementing caseInsensitive id search
+    caseInsensitiveSubjects: false,
+
     btnPanelPrefix: 'btnPanel',
     totalPanelPrefix: 'totalPanel',
     btnPrefix: 'btn',
@@ -1015,7 +1018,7 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
             var cfg = Ext4.apply({}, filterType);
             cfg.tabbedReportPanel = this;
             cfg.filterContext = this.getFilterContext();
-            cfg.caseInsensitive = this.caseInsensitive;
+            cfg.caseInsensitive = this.caseInsensitiveSubjects;
 
             if (this.activeFilterType){
                 this.activeFilterType.prepareRemove();


### PR DESCRIPTION
#### Rationale
Case insensitive flag allows case insensitive Id matching. Move this to a top level variable on TabbedReportPanel instead of a filter level variable.  Update splitIds to respect caseInsensitive.

#### Changes
* Update splitIds with caseInsensitive case
* Update calls to splitIds
* Apply caseInsensitive to filter config from TabbedReportPanel
