### PR TITLE
remove reference to internal module in dependencies

### DIFF
--- a/LDK/build.gradle
+++ b/LDK/build.gradle
@@ -8,7 +8,6 @@ dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"), depProjectConfig: 'apiJarFile')
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "api"), depProjectConfig: "published", depExtension: "module")
-   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "internal"), depProjectConfig: "published", depExtension: "module")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"), depProjectConfig: "published", depExtension: "module")
 
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "assay"), depProjectConfig: "published", depExtension: "module")


### PR DESCRIPTION
#### Rationale
The guts of the internal module were moved elsewhere with [platform PR #4015](https://github.com/LabKey/platform/pull/4015).  Now we remove it entirely.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/166
* https://github.com/LabKey/server/pull/398

#### Changes
* Remove references to the "platform/internal" module