### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/LDK/src/org/labkey/ldk/query/AbstractIntegrationTest.java
+++ b/LDK/src/org/labkey/ldk/query/AbstractIntegrationTest.java
@@ -31,7 +31,7 @@ public class AbstractIntegrationTest extends Assert
         Container project = ContainerManager.getForPath(projectName);
         if (project == null)
         {
-            ContainerManager.createContainer(ContainerManager.getRoot(), projectName);
+            ContainerManager.createContainer(ContainerManager.getRoot(), projectName, TestContext.get().getUser());
         }
     }
 


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers