### PR TITLE
QCStates filter on animal history

### DIFF
--- a/LDK/resources/web/LDK/panel/AbstractFilterType.js
+++ b/LDK/resources/web/LDK/panel/AbstractFilterType.js
@@ -34,7 +34,7 @@ Ext4.define('LDK.panel.AbstractFilterType', {
     },
 
     getFilterArray: function(tab, subject){
-        filterArray = {
+        let filterArray = {
             removable: [],
             nonRemovable: []
         };

--- a/LDK/resources/web/LDK/panel/AbstractFilterType.js
+++ b/LDK/resources/web/LDK/panel/AbstractFilterType.js
@@ -1,6 +1,9 @@
 Ext4.define('LDK.panel.AbstractFilterType', {
     extend: 'Ext.panel.Panel',
 
+    // This is passed to the filter types to apply a non-removable filter on these QC state labels
+    reportQCStates: [],
+
     initComponent: function(){
         Ext4.apply(this, {
             layout: 'hbox',
@@ -31,10 +34,16 @@ Ext4.define('LDK.panel.AbstractFilterType', {
     },
 
     getFilterArray: function(tab, subject){
-        return {
+        filterArray = {
             removable: [],
             nonRemovable: []
         };
+
+        if (this.reportQCStates?.length) {
+            filterArray.nonRemovable.push(LABKEY.Filter.create('qcstate/label', this.reportQCStates, LABKEY.Filter.Types.EQUALS_ONE_OF));
+        }
+
+        return filterArray;
     },
 
     getTitle: function(){

--- a/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
+++ b/LDK/resources/web/LDK/panel/SingleSubjectFilterType.js
@@ -64,6 +64,10 @@ Ext4.define('LDK.panel.SingleSubjectFilterType', {
             nonRemovable: []
         };
 
+        if (this.reportQCStates?.length) {
+            filterArray.nonRemovable.push(LABKEY.Filter.create('qcstate/label', this.reportQCStates, LABKEY.Filter.Types.EQUALS_ONE_OF));
+        }
+
         var subjectFieldName;
         if(tab.report) {
             subjectFieldName = tab.report.subjectFieldName;

--- a/LDK/resources/web/LDK/panel/TabbedReportPanel.js
+++ b/LDK/resources/web/LDK/panel/TabbedReportPanel.js
@@ -31,6 +31,9 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
     // Passed to filters implementing caseInsensitive id search
     caseInsensitiveSubjects: false,
 
+    // Passed to filters implementing reportQCStates filter
+    reportQCStates: false,
+
     btnPanelPrefix: 'btnPanel',
     totalPanelPrefix: 'totalPanel',
     btnPrefix: 'btn',
@@ -1019,6 +1022,7 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
             cfg.tabbedReportPanel = this;
             cfg.filterContext = this.getFilterContext();
             cfg.caseInsensitive = this.caseInsensitiveSubjects;
+            cfg.reportQCStates = this.reportQCStates || [];
 
             if (this.activeFilterType){
                 this.activeFilterType.prepareRemove();

--- a/LDK/resources/web/LDK/panel/TabbedReportPanel.js
+++ b/LDK/resources/web/LDK/panel/TabbedReportPanel.js
@@ -32,7 +32,7 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
     caseInsensitiveSubjects: false,
 
     // Passed to filters implementing reportQCStates filter
-    reportQCStates: false,
+    reportQCStates: [],
 
     btnPanelPrefix: 'btnPanel',
     totalPanelPrefix: 'totalPanel',
@@ -1022,7 +1022,7 @@ Ext4.define('LDK.panel.TabbedReportPanel', {
             cfg.tabbedReportPanel = this;
             cfg.filterContext = this.getFilterContext();
             cfg.caseInsensitive = this.caseInsensitiveSubjects;
-            cfg.reportQCStates = this.reportQCStates || [];
+            cfg.reportQCStates = this.reportQCStates;
 
             if (this.activeFilterType){
                 this.activeFilterType.prepareRemove();

--- a/laboratory/resources/web/laboratory/panel/ProjectFilterType.js
+++ b/laboratory/resources/web/laboratory/panel/ProjectFilterType.js
@@ -77,6 +77,10 @@ Ext4.define('Laboratory.panel.ProjectFilterType', {
             nonRemovable: []
         };
 
+        if (this.reportQCStates?.length) {
+            filterArray.nonRemovable.push(LABKEY.Filter.create('qcstate/label', this.reportQCStates, LABKEY.Filter.Types.EQUALS_ONE_OF));
+        }
+
         var filters = this.getFilters();
         var report = tab.report;
         var projectFieldName = (filters.projectFilterMode === 'overlappingProjects') ? report.overlappingProjectsFieldName : report.allProjectsFieldName;


### PR DESCRIPTION
#### Rationale
This provides an optional way to apply a QCState filter to animal history reports. This will be a non-removable filter on qcstate/label matching one of an array of QCStates. If reportQCStates is not defined, no filter will be applied.

#### Changes
* Add reportQCStates prop to TabbedReportPanel (passed on to filter types)
* Add reportQCStates prop to filter types and add non-removable filter
