### PR TITLE
fix ehr tests that are enabling notifications

### DIFF
--- a/LDK/resources/web/LDK/panel/NotificationAdminPanel.js
+++ b/LDK/resources/web/LDK/panel/NotificationAdminPanel.js
@@ -198,7 +198,7 @@ Ext4.define('LDK.panel.NotificationAdminPanel', {
                 helpPopup: 'This will be used as the reply email for all sent messages.',
                 dataIndex: 'replyEmail',
                 vtype: 'email',
-                value: results.replyEmail
+                value: results.replyEmail.address
             },{
                 xtype: 'panel',
                 border: false,


### PR DESCRIPTION
#### Rationale
Some changes along the way for tomcat 10 upgrade caused the get notifications object to return in a more structured json. This PR fixes the setting of email field on the notification admin form to display the email value rather than [object, object].

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
