### PR TITLE
Use ensureTransaction instead of beginTransaction

### DIFF
--- a/laboratory/src/org/labkey/laboratory/LaboratoryManager.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryManager.java
@@ -121,7 +121,7 @@ public class LaboratoryManager
 
         if (!rows.isEmpty())
         {
-            try (DbScope.Transaction t = workbookDbTable.getSchema().getScope().beginTransaction())
+            try (DbScope.Transaction t = workbookDbTable.getSchema().getScope().ensureTransaction())
             {
                 rows.forEach(wb -> Table.insert(u, workbookDbTable, wb));
                 t.commit();


### PR DESCRIPTION
#### Rationale
`beginTransaction()` gets a new DB connection and starts a transaction, even if there's already a transaction underway. This can lead to self-deadlocks and other problems.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5278

#### Changes
* Switch callers to use `ensureTransaction()`