### PR TITLE
Mark modules that support both databases

### DIFF
--- a/LDK/module.properties
+++ b/LDK/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.ldk.LDKModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/laboratory/module.properties
+++ b/laboratory/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.laboratory.LaboratoryModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only