### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/LDK/resources/views/apiBulkEdit.view.xml
+++ b/LDK/resources/views/apiBulkEdit.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Bulk Edit Using Client API">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
 

--- a/LDK/resources/views/folderSizeSummary.view.xml
+++ b/LDK/resources/views/folderSizeSummary.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Folder Size Summary">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/LDK/resources/views/manageRecord.view.xml
+++ b/LDK/resources/views/manageRecord.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manage Record" frame="portal">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4ClientApi"/>
     </dependencies>

--- a/LDK/resources/views/notificationAdmin.view.xml
+++ b/LDK/resources/views/notificationAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Notification Management">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="Security/util/SecurityCache.js"/>

--- a/LDK/resources/views/notificationSiteAdmin.view.xml
+++ b/LDK/resources/views/notificationSiteAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Notification Site Admin">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
         <dependency path="Security/util/SecurityCache.js"/>

--- a/LDK/resources/views/setRedirectUrl.view.xml
+++ b/LDK/resources/views/setRedirectUrl.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ldk.context"/>
     </dependencies>

--- a/laboratory/resources/views/assayDefaults.view.xml
+++ b/laboratory/resources/views/assayDefaults.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Assay Defaults">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.laboratory.security.LaboratoryAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
         <dependency path="laboratory/panel/AssayDefaultsPanel.js"/>

--- a/laboratory/resources/views/customizeDataBrowser.view.xml
+++ b/laboratory/resources/views/customizeDataBrowser.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Customize Data Browser">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.laboratory.security.LaboratoryAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
         <dependency path="laboratory/panel/CustomizeDataBrowserPanel.js"/>

--- a/laboratory/resources/views/itemDefaultViews.view.xml
+++ b/laboratory/resources/views/itemDefaultViews.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Item Default Views">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.laboratory.security.LaboratoryAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
         <dependency path="laboratory/panel/ItemDefaultViewsPanel.js"/>

--- a/laboratory/resources/views/itemVisibility.view.xml
+++ b/laboratory/resources/views/itemVisibility.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Item Visibility">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.laboratory.security.LaboratoryAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
         <dependency path="laboratory/panel/ItemVisibilityPanel.js"/>

--- a/laboratory/resources/views/manageDataSources.view.xml
+++ b/laboratory/resources/views/manageDataSources.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manage Data Sources">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.laboratory.security.LaboratoryAdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
         <dependency path="laboratory/panel/QueryPickerPanel.js"/>

--- a/laboratory/resources/views/siteLabSettings.view.xml
+++ b/laboratory/resources/views/siteLabSettings.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Site Settings For DISCVR Modules">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
     </dependencies>

--- a/laboratory/resources/views/synchronizeAssayFields.view.xml
+++ b/laboratory/resources/views/synchronizeAssayFields.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Synchronize Assay Fields">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="laboratory.context"/>
     </dependencies>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.