### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/LDK/resources/web/LDK/Utils.js
+++ b/LDK/resources/web/LDK/Utils.js
@@ -365,16 +365,16 @@ LDK.Utils = new function(){
         },
 
         /**
-         * Returns the current URL, encoded, minus the origin, which is suitable to use as a srcURL param.
+         * Returns the current URL, encoded, minus the origin, which is suitable to use as a returnUrl param.
          */
-        getSrcURL: function(){
+        getReturnUrl: function(){
             var re = new RegExp('^' + window.location.origin);
             return encodeURIComponent(window.location.href.replace(re, ''));
         },
 
         /**
          * Create immutable object.  Usage:
-         * var sealedObj = new LABKEU.Utils.sealed(obj);
+         * var sealedObj = new LABKEY.Utils.sealed(obj);
          *
          * @param obj The object to seal
          * @returns The sealed object

--- a/LDK/resources/web/LDK/panel/NavPanel.js
+++ b/LDK/resources/web/LDK/panel/NavPanel.js
@@ -250,7 +250,7 @@ Ext4.define('LDK.panel.NavPanel', {
                 if (!item.assayRunTemplateUrl || LABKEY.Utils.isEmptyObj(item.assayRunTemplateUrl)){
                     cfg.items.push(this.getImportItemCfg(item, {
                         urlConfig: {
-                            params: Ext4.apply({srcURL: LABKEY.ActionURL.buildURL('project', 'begin')}, item.importUrl.params),
+                            params: Ext4.apply({returnUrl: LABKEY.ActionURL.buildURL('project', 'begin')}, item.importUrl.params),
                             action: item.importUrl.action,
                             controller: item.importUrl.controller
                         },
@@ -336,7 +336,7 @@ Ext4.define('LDK.panel.NavPanel', {
                         urlConfig: {
                             action: 'importData',
                             controller: 'query',
-                            params: {schemaName: item.schemaName, queryName: item.queryName, srcURL: LABKEY.ActionURL.buildURL('project', 'begin')}
+                            params: {schemaName: item.schemaName, queryName: item.queryName, returnUrl: LABKEY.ActionURL.buildURL('project', 'begin')}
                         }
                     })
                 ]

--- a/laboratory/resources/web/laboratory/panel/AssayImportPanel.js
+++ b/laboratory/resources/web/laboratory/panel/AssayImportPanel.js
@@ -69,7 +69,7 @@ Ext4.define('Laboratory.panel.AssayImportPanel', {
                     text: 'Cancel',
                     itemId: 'cancelBtn',
                     scope: this,
-                    href: LABKEY.ActionURL.getParameter('srcURL') || LABKEY.ActionURL.buildURL('project', 'begin'),
+                    href: LABKEY.ActionURL.getParameter('returnUrl') || LABKEY.ActionURL.buildURL('project', 'begin'),
                     hrefTarget: '_self'
                 }]
             }],
@@ -404,7 +404,7 @@ Ext4.define('Laboratory.panel.AssayImportPanel', {
         Ext4.Msg.hide();
         Ext4.Msg.alert('Success', 'Your upload was successful!', function(){
             function doLoad(){
-                //NOTE: always return to the project root, ignoring srcURL
+                //NOTE: always return to the project root, ignoring returnUrl
                 window.location = LABKEY.ActionURL.buildURL('project', 'begin');
             }
 

--- a/laboratory/src/org/labkey/laboratory/LaboratoryController.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryController.java
@@ -271,7 +271,7 @@ public class LaboratoryController extends SpringActionController
                     url.addParameter("renameConflicts", true);
                     url.addParameter("providerName", form.getProviderName());
                     if (form.getReturnActionURL() != null)
-                        url.addReturnURL(form.getReturnActionURL());
+                        url.addReturnUrl(form.getReturnActionURL());
                     form.setReturnUrl(url.getLocalURIString());
                 }
 

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -395,7 +395,7 @@ public class AssayHelper
                                     url.addParameter("providerName", ap.getName());
 
                                     ActionURL returnUrl = new ActionURL("laboratory", "synchronizeAssayFields.view", ContainerManager.getSharedContainer());
-                                    url.addReturnURL(returnUrl);
+                                    url.addReturnUrl(returnUrl);
                                     msg += "This will not be changed automatically.  If do you want to correct this, <a href=\"" + url + "\">CLICK HERE</a>.";
                                 }
                                 else


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters