### PR TITLE
Add brackets in UserEditableCombo dropdowns around broken lookups

### DIFF
--- a/LDK/resources/web/LDK/plugin/UserEditableCombo.js
+++ b/LDK/resources/web/LDK/plugin/UserEditableCombo.js
@@ -94,31 +94,36 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
                 this.addValueIfNeeded(val);
 
                 this.callOverridden(arguments);
-            },
-            tpl: Ext4.create('Ext.XTemplate',
-                '<ul class="x4-list-plain">',
-                    '<tpl for=".">',
-                        '<li role="option" class="x4-boundlist-item">',
-                            '{[this.formatLookup(values)]}',
-                        '</li>',
-                    '</tpl>',
-                '</ul>',
-                {
-                    formatLookup: function(value) {
-                        const val = value[this.field.displayField] || value[this.field.valueField] || '';
-                        if (Ext4.isEmpty(val)) {
-                            return '';
-                        }
-
-                        if (this.field.userEditablePlugin.useBracketsForUnknownValues && value.invalid) {
-                            return '[' + LABKEY.Utils.encodeHtml(val) + ']';
-                        }
-
-                        return LABKEY.Utils.encodeHtml(val);
-                    }
-                }
-            )
+            }
         });
+
+        if (this.useBracketsForUnknownValues) {
+            Ext4.override(combo, {
+                tpl: Ext4.create('Ext.XTemplate',
+                    '<ul class="x4-list-plain">',
+                        '<tpl for=".">',
+                            '<li role="option" class="x4-boundlist-item">',
+                                '{[this.formatLookup(values)]}',
+                            '</li>',
+                        '</tpl>',
+                    '</ul>',
+                    {
+                        formatLookup: function(value) {
+                            const val = value[this.field.displayField] || value[this.field.valueField] || '';
+                            if (Ext4.isEmpty(val)) {
+                                return '';
+                            }
+
+                            if (value.invalid) {
+                                return '[' + LABKEY.Utils.encodeHtml(val) + ']';
+                            }
+
+                            return LABKEY.Utils.encodeHtml(val);
+                        }
+                    }
+                )
+            });
+        }
 
         combo.store.on('add', this.onStoreAdd, this);
         combo.store.on('load', combo.ensureValueInStore, combo);

--- a/LDK/resources/web/LDK/plugin/UserEditableCombo.js
+++ b/LDK/resources/web/LDK/plugin/UserEditableCombo.js
@@ -84,6 +84,7 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
                 var rec = this.store.createModel({});
                 rec.set(this.valueField, val);
                 rec.set(this.displayField, val);
+                rec.set("invalid", true);
 
                 this.store.add(rec);
             },
@@ -92,7 +93,30 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
                 this.addValueIfNeeded(val);
 
                 this.callOverridden(arguments);
-            }
+            },
+            tpl: Ext4.create('Ext.XTemplate',
+                '<ul class="x4-list-plain">',
+                    '<tpl for=".">',
+                        '<li role="option" class="x4-boundlist-item">',
+                            '{[this.formatLookup(values)]}',
+                        '</li>',
+                    '</tpl>',
+                '</ul>',
+                {
+                    formatLookup: function(value) {
+                        const val = value[this.field.displayField] || value[this.field.valueField] || '';
+                        if (Ext4.isEmpty(val)) {
+                            return '';
+                        }
+
+                        if (value.invalid) {
+                            return '[' + LABKEY.Utils.encodeHtml(val) + ']';
+                        }
+
+                        return LABKEY.Utils.encodeHtml(val);
+                    }
+                }
+            )
         });
 
         combo.store.on('add', this.onStoreAdd, this);

--- a/LDK/resources/web/LDK/plugin/UserEditableCombo.js
+++ b/LDK/resources/web/LDK/plugin/UserEditableCombo.js
@@ -12,6 +12,7 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
 
     alias: 'plugin.ldk-usereditablecombo',
     allowChooseOther: true,
+    useBracketsForUnknownValues: false,
 
     init: function(combo) {
         this.combo = combo;
@@ -109,7 +110,7 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
                             return '';
                         }
 
-                        if (value.invalid) {
+                        if (this.field.userEditablePlugin.useBracketsForUnknownValues && value.invalid) {
                             return '[' + LABKEY.Utils.encodeHtml(val) + ']';
                         }
 

--- a/LDK/resources/web/LDK/plugin/UserEditableCombo.js
+++ b/LDK/resources/web/LDK/plugin/UserEditableCombo.js
@@ -98,12 +98,25 @@ Ext4.define('LDK.plugin.UserEditableCombo', {
         });
 
         if (this.useBracketsForUnknownValues) {
+            let innerTpl = 'this.formatLookup(values)';
+
+            const innerTplWrap = this.combo?.listConfig?.getInnerTpl();
+            if (typeof innerTplWrap === 'string') {
+                innerTpl = innerTplWrap.replaceAll('values', innerTpl);
+            }
+            else if (Array.isArray(innerTplWrap)) {
+                innerTpl = innerTplWrap.map(t => t.replaceAll('values', innerTpl));
+            }
+            else {
+                innerTpl = '{[' + innerTpl + ']}';
+            }
+
             Ext4.override(combo, {
                 tpl: Ext4.create('Ext.XTemplate',
                     '<ul class="x4-list-plain">',
                         '<tpl for=".">',
                             '<li role="option" class="x4-boundlist-item">',
-                                '{[this.formatLookup(values)]}',
+                                '' + innerTpl,
                             '</li>',
                         '</tpl>',
                     '</ul>',


### PR DESCRIPTION
#### Rationale
UserEditableCombo is now the default combo input if there are broken lookups. This adds a tpl to put the broken lookups in the dropdown in brackets.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/958

#### Changes
* Add tpl to dropdown
