### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/LDK/api-src/org/labkey/api/ldk/table/AbstractTableCustomizer.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/AbstractTableCustomizer.java
@@ -42,7 +42,7 @@ abstract public class AbstractTableCustomizer implements TableCustomizer
      * Rely on DefaultSchema's caching of schema creation, and just track the minimum number of DefaultSchemas to
      * resolve the requested collection of target containers
      */
-    private Map<Container, DefaultSchema> _defaultSchemas = new HashMap<>();
+    private final Map<Container, DefaultSchema> _defaultSchemas = new HashMap<>();
 
     public UserSchema getUserSchema(AbstractTableInfo ti, String name)
     {

--- a/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
@@ -242,7 +242,7 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
             final String containerColName = getContainerFilterColumn();
             final KeyManager keyManager = new KeyManager();
             final SimpleTranslator it = new SimpleTranslator(input, context);
-            final Map<String, Integer> inputColMap = new HashMap<String, Integer>();
+            final Map<String, Integer> inputColMap = new HashMap<>();
             for (int idx = 1; idx <= input.getColumnCount(); idx++)
             {
                 ColumnInfo col = input.getColumnInfo(idx);
@@ -262,7 +262,7 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
 
             //set the value of the RowId column
             ColumnInfo pseudoPkCol = getColumn(_pseudoPk);
-            it.addColumn(pseudoPkCol, new Callable<Object>()
+            it.addColumn(pseudoPkCol, new Callable<>()
             {
                 @Override
                 public Object call()
@@ -270,7 +270,7 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
                     Container c = null;
                     if (inputColMap.containsKey(containerColName))
                     {
-                        String containerId = (String)it.getInputColumnValue(inputColMap.get(containerColName));
+                        String containerId = (String) it.getInputColumnValue(inputColMap.get(containerColName));
                         if (containerId != null)
                             c = ContainerManager.getForId(containerId);
                     }

--- a/LDK/api-src/org/labkey/api/ldk/table/CustomPermissionsTable.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/CustomPermissionsTable.java
@@ -34,7 +34,7 @@ import java.util.Map;
  */
 public class CustomPermissionsTable<SchemaType extends UserSchema> extends SimpleUserSchema.SimpleTable<SchemaType>
 {
-    private Map<Class<? extends Permission>, Class<? extends Permission>> _permMap = new HashMap<>();
+    private final Map<Class<? extends Permission>, Class<? extends Permission>> _permMap = new HashMap<>();
 
     public CustomPermissionsTable(SchemaType schema, TableInfo table, ContainerFilter cf)
     {

--- a/LDK/api-src/org/labkey/api/ldk/table/QueryCache.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/QueryCache.java
@@ -46,10 +46,10 @@ public class QueryCache
 {
     private static final Logger _log = LogManager.getLogger(QueryCache.class);
 
-    private Map<String, AssayProtocolSchema> _cachedAssaySchemas = new HashMap<>();
-    private Map<String, UserSchema> _cachedUserSchemas = new HashMap<>();
-    private Map<String, TableInfo> _cachedQueries = new HashMap<>();
-    private Map<String, ColumnInfo> _cachedColumns = new HashMap<>();
+    private final Map<String, AssayProtocolSchema> _cachedAssaySchemas = new HashMap<>();
+    private final Map<String, UserSchema> _cachedUserSchemas = new HashMap<>();
+    private final Map<String, TableInfo> _cachedQueries = new HashMap<>();
+    private final Map<String, ColumnInfo> _cachedColumns = new HashMap<>();
 
     public QueryCache()
     {
@@ -104,7 +104,7 @@ public class QueryCache
 
             List<QueryException> errors = new ArrayList<>();
             TableInfo ti = qd.getTable(errors, true);
-            if (errors.size() > 0)
+            if (!errors.isEmpty())
             {
                 _log.error("Unable to create tabbed report item for query: " + schemaPath + "." + queryName + " in " + targetContainer.getPath());
                 for (QueryException e : errors)

--- a/LDK/api-src/org/labkey/api/ldk/table/SimpleButtonConfigFactory.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/SimpleButtonConfigFactory.java
@@ -39,8 +39,8 @@ import java.util.function.Supplier;
  */
 public class SimpleButtonConfigFactory implements ButtonConfigFactory
 {
-    private Module _owner;
-    private String _text;
+    private final Module _owner;
+    private final String _text;
     private DetailsURL _url = null;
     private String _jsHandler = null;
     private Integer _insertPosition = null;

--- a/LDK/src/org/labkey/ldk/LDKController.java
+++ b/LDK/src/org/labkey/ldk/LDKController.java
@@ -111,7 +111,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetNotificationsAction extends ReadOnlyApiAction<Object>
+    public static class GetNotificationsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -136,7 +136,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetFileRootSizesAction extends ReadOnlyApiAction<FileRootSizeForm>
+    public static class GetFileRootSizesAction extends ReadOnlyApiAction<FileRootSizeForm>
     {
         @Override
         public ApiResponse execute(FileRootSizeForm form, BindException errors) throws Exception
@@ -212,7 +212,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class GetSiteNotificationDetailsAction extends ReadOnlyApiAction<Object>
+    public static class GetSiteNotificationDetailsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors) throws Exception
@@ -242,7 +242,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class UpdateNotificationSubscriptionsAction extends MutatingApiAction<UpdateNotificationSubscriptionsForm>
+    public static class UpdateNotificationSubscriptionsAction extends MutatingApiAction<UpdateNotificationSubscriptionsForm>
     {
         @Override
         public ApiResponse execute(UpdateNotificationSubscriptionsForm form, BindException errors) throws Exception
@@ -349,7 +349,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class RunNotificationAction extends SimpleViewAction<RunNotificationForm>
+    public static class RunNotificationAction extends SimpleViewAction<RunNotificationForm>
     {
         private String _title = null;
 
@@ -403,7 +403,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SendNotificationAction extends MutatingApiAction<RunNotificationForm>
+    public static class SendNotificationAction extends MutatingApiAction<RunNotificationForm>
     {
         @Override
         public ApiResponse execute(RunNotificationForm form, BindException errors) throws Exception
@@ -437,7 +437,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ValidateContainerScopedTablesAction extends SimpleViewAction<Object>
+    public static class ValidateContainerScopedTablesAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object form, BindException errors) throws Exception
@@ -459,7 +459,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class GetNotificationSubscriptionsAction extends ReadOnlyApiAction<RunNotificationForm>
+    public static class GetNotificationSubscriptionsAction extends ReadOnlyApiAction<RunNotificationForm>
     {
         @Override
         public ApiResponse execute(RunNotificationForm form, BindException errors) throws Exception
@@ -509,7 +509,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SetNotificationSettingsAction extends MutatingApiAction<NotificationSettingsForm>
+    public static class SetNotificationSettingsAction extends MutatingApiAction<NotificationSettingsForm>
     {
         @Override
         public ApiResponse execute(NotificationSettingsForm form, BindException errors)
@@ -648,7 +648,7 @@ public class LDKController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class LogMetricAction extends MutatingApiAction<LogMetricForm>
+    public static class LogMetricAction extends MutatingApiAction<LogMetricForm>
     {
         @Override
         public ApiResponse execute(LogMetricForm form, BindException errors) throws Exception
@@ -822,7 +822,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class UpdateQueryAction extends SimpleViewAction<QueryForm>
+    public static class UpdateQueryAction extends SimpleViewAction<QueryForm>
     {
         private QueryForm _form;
 
@@ -1019,7 +1019,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresNoPermission
-    public class RedirectStartAction extends SimpleViewAction<Object>
+    public static class RedirectStartAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object form, BindException errors) throws Exception
@@ -1065,7 +1065,7 @@ public class LDKController extends SpringActionController
     public static final String REDIRECT_URL_PROP = "redirectURL";
 
     @RequiresPermission(AdminPermission.class)
-    public class SetRedirectUrlAction extends MutatingApiAction<SetRedirectUrlForm>
+    public static class SetRedirectUrlAction extends MutatingApiAction<SetRedirectUrlForm>
     {
         @Override
         public ApiResponse execute(SetRedirectUrlForm form, BindException errors) throws Exception
@@ -1100,7 +1100,7 @@ public class LDKController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class GetRedirectUrlAction extends ReadOnlyApiAction<Object>
+    public static class GetRedirectUrlAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors) throws Exception
@@ -1111,7 +1111,7 @@ public class LDKController extends SpringActionController
 
     @RequiresPermission(AdminOperationsPermission.class)
     @AllowedDuringUpgrade
-    public class DownloadNaturalizeInstallScriptAction extends ExportAction<Object>
+    public static class DownloadNaturalizeInstallScriptAction extends ExportAction<Object>
     {
         @Override
         public void export(Object o, HttpServletResponse response, BindException errors) throws Exception

--- a/LDK/src/org/labkey/ldk/LDKServiceImpl.java
+++ b/LDK/src/org/labkey/ldk/LDKServiceImpl.java
@@ -60,7 +60,7 @@ public class LDKServiceImpl extends LDKService
     private final Set<NotificationSection> _summaryNotificationSections = new HashSet<>();
     private final List<List<String>> _containerScopedTables = new ArrayList<>();
     private Boolean _isNaturalizeInstalled = null;
-    private final Map<String, Map<String, List<ButtonConfigFactory>>> _queryButtons = new CaseInsensitiveHashMap<Map<String, List<ButtonConfigFactory>>>();
+    private final Map<String, Map<String, List<ButtonConfigFactory>>> _queryButtons = new CaseInsensitiveHashMap<>();
     private static final String BACKGROUND_USER_PROPNAME = "BackgroundAdminUser";
 
     public LDKServiceImpl()
@@ -113,7 +113,7 @@ public class LDKServiceImpl extends LDKService
         //append children
         if (includeAllRootTypes)
         {
-            Set<File> paths = new HashSet<File>();
+            Set<File> paths = new HashSet<>();
             for (FileContentService.ContentType type : FileContentService.ContentType.values())
             {
                 File fileRoot = svc.getFileRoot(c, type);
@@ -268,7 +268,7 @@ public class LDKServiceImpl extends LDKService
             if (ss.exists())
             {
                 messages.add("ERROR: duplicates found in: " + values.get(0) + "." + values.get(1));
-                ss.forEach(new Selector.ForEachBlock<ResultSet>()
+                ss.forEach(new Selector.ForEachBlock<>()
                 {
                     @Override
                     public void exec(ResultSet rs) throws SQLException
@@ -334,11 +334,11 @@ public class LDKServiceImpl extends LDKService
     {
         Map<String, List<ButtonConfigFactory>> schemaMap = _queryButtons.get(schema);
         if (schemaMap == null)
-            schemaMap = new CaseInsensitiveHashMap<List<ButtonConfigFactory>>();
+            schemaMap = new CaseInsensitiveHashMap<>();
 
         List<ButtonConfigFactory> list = schemaMap.get(query);
         if (list == null)
-            list = new ArrayList<ButtonConfigFactory>();
+            list = new ArrayList<>();
 
         list.add(btn);
 
@@ -349,7 +349,7 @@ public class LDKServiceImpl extends LDKService
     @Override
     public List<ButtonConfigFactory> getQueryButtons(TableInfo ti)
     {
-        List<ButtonConfigFactory> buttons = new ArrayList<ButtonConfigFactory>();
+        List<ButtonConfigFactory> buttons = new ArrayList<>();
 
         Map<String, List<ButtonConfigFactory>> factories = _queryButtons.get(ti.getPublicSchemaName());
         if (factories == null)

--- a/LDK/src/org/labkey/ldk/notification/NotificationJob.java
+++ b/LDK/src/org/labkey/ldk/notification/NotificationJob.java
@@ -42,7 +42,7 @@ public class NotificationJob implements Job
         _log.info("Trying to run notification: " + _notification.getName());
 
         Set<Container> activeContainers = NotificationServiceImpl.get().getActiveContainers(_notification);
-        if (activeContainers.size() == 0)
+        if (activeContainers.isEmpty())
         {
             _log.info("there are no active containers, skipping");
         }

--- a/LDK/src/org/labkey/ldk/notification/NotificationServiceImpl.java
+++ b/LDK/src/org/labkey/ldk/notification/NotificationServiceImpl.java
@@ -466,7 +466,8 @@ public class NotificationServiceImpl extends NotificationService
         TableSelector ts = new TableSelector(t, Collections.singleton("recipient"), filter, null);
         if (ts.getRowCount() > 0)
         {
-            ts.forEach(new TableSelector.ForEachBlock<ResultSet>(){
+            ts.forEach(new TableSelector.ForEachBlock<>()
+            {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
                 {
@@ -586,7 +587,7 @@ public class NotificationServiceImpl extends NotificationService
         }
 
         List<Address> recipients = NotificationServiceImpl.get().getEmails(notification, c);
-        if (recipients.size() == 0)
+        if (recipients.isEmpty())
         {
             _log.info("Notification: " + notification.getName() + " has no recipients, skipping");
             return;
@@ -605,7 +606,7 @@ public class NotificationServiceImpl extends NotificationService
 
             mail.setFrom(NotificationServiceImpl.get().getReturnEmail(c));
             mail.setSubject(notification.getEmailSubject(c));
-            mail.addRecipients(Message.RecipientType.TO, recipients.toArray(new Address[recipients.size()]));
+            mail.addRecipients(Message.RecipientType.TO, recipients.toArray(new Address[0]));
 
             MailHelper.send(mail, u, c);
         }

--- a/LDK/src/org/labkey/ldk/notification/SiteSummaryNotification.java
+++ b/LDK/src/org/labkey/ldk/notification/SiteSummaryNotification.java
@@ -189,7 +189,7 @@ public class SiteSummaryNotification implements Notification
         _pctFormat.setMaximumFractionDigits(1);
 
         Map<String, String> saved = getSavedValues(c);
-        Map<String, String> newValues = new HashMap<String, String>();
+        Map<String, String> newValues = new HashMap<>();
 
         StringBuilder msg = new StringBuilder();
         StringBuilder alerts = new StringBuilder();
@@ -214,7 +214,7 @@ public class SiteSummaryNotification implements Notification
             }
         }
 
-        if (alerts.length() > 0)
+        if (!alerts.isEmpty())
         {
             alerts.insert(0, "<b>The following alerts were generated:</b><p>");
             alerts.append("<hr>");
@@ -261,7 +261,7 @@ public class SiteSummaryNotification implements Notification
 
             msg.append("<b>Site Logins In The Past 7 Days:</b><br>\n");
             msg.append("<table border=1 style='border-collapse: collapse;'><tr style='font-weight: bold;'><td>Day of Week</td><td>Date</td><td>Logins</td><td>Distinct Users</td><td>Logins / User</td></tr>");
-            ss.forEach(new Selector.ForEachBlock<ResultSet>()
+            ss.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -296,7 +296,7 @@ public class SiteSummaryNotification implements Notification
 
         msg.append("Number of Forms Created Yesterday: <br>\n");
 
-        ss.forEach(new Selector.ForEachBlock<ResultSet>()
+        ss.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException
@@ -314,7 +314,7 @@ public class SiteSummaryNotification implements Notification
         String studySize = "studySize";
         if (!studies.isEmpty())
         {
-            Map<String, String> newValueMap = new HashMap<String, String>();
+            Map<String, String> newValueMap = new HashMap<>();
             JSONObject oldValueMap = null;
             if (saved.containsKey(studySize))
             {
@@ -343,7 +343,7 @@ public class SiteSummaryNotification implements Notification
 
             msg.append("</table>");
 
-            if (newValueMap.size() > 0)
+            if (!newValueMap.isEmpty())
                 toSave.put(studySize, new JSONObject(newValueMap).toString());
         }
     }
@@ -458,9 +458,9 @@ public class SiteSummaryNotification implements Notification
         msg.append("</table><br>");
         msg.append("<hr>");
 
-        if (newValueMap.size() > 0)
+        if (!newValueMap.isEmpty())
             toSave.put(fileRootSizes, new JSONObject(newValueMap).toString());
-        if (newValueMapCounts.size() > 0)
+        if (!newValueMapCounts.isEmpty())
             toSave.put(fileRootCounts, new JSONObject(newValueMapCounts).toString());
     }
 
@@ -502,7 +502,7 @@ public class SiteSummaryNotification implements Notification
             final Map<String, String> newValueMap = new HashMap<>();
             final JSONObject oldValueMap = saved.containsKey(tableSizes) ? new JSONObject(saved.get(tableSizes)) : null;
 
-            ss.forEach(new Selector.ForEachBlock<ResultSet>()
+            ss.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet object) throws SQLException
@@ -519,14 +519,14 @@ public class SiteSummaryNotification implements Notification
                         previousValue = oldValueMap.getLong(key);
                     }
 
-                    String pctChange = getPctChange(previousValue, total, 0.05, "The number of rows in the table " +  key + " has changed signficiantly since the last run on " + getLastSaveString(c, saved), alerts);
+                    String pctChange = getPctChange(previousValue, total, 0.05, "The number of rows in the table " + key + " has changed signficiantly since the last run on " + getLastSaveString(c, saved), alerts);
                     msg.append("<tr><td>" + (schema == null ? "" : schema) + "</td><td>" + (table == null ? "" : table) + "</td><td>" + (total == null ? "" : NumberFormat.getInstance().format(total)) + "</td><td>" + (previousValue == null ? "" : NumberFormat.getInstance().format(previousValue)) + "</td>" + pctChange + "</tr>");
                 }
             });
 
             msg.append("</table><br>");
 
-            if (newValueMap.size() > 0)
+            if (!newValueMap.isEmpty())
                 toSave.put(tableSizes, new JSONObject(newValueMap).toString());
         }
 
@@ -543,7 +543,7 @@ public class SiteSummaryNotification implements Notification
         SqlSelector ss;
 
         String dbSizes = "dbSizes";
-        final Map<String, String> newValueMap = new HashMap<String, String>();
+        final Map<String, String> newValueMap = new HashMap<>();
         final JSONObject oldValueMap = saved.containsKey(dbSizes) ? new JSONObject(saved.get(dbSizes)) : null;
 
         if (DbScope.getLabKeyScope().getSqlDialect().isSqlServer())
@@ -560,10 +560,10 @@ public class SiteSummaryNotification implements Notification
                 msg.append("<table border=1 style='border-collapse: collapse;'><tr style='font-weight:bold;'><td>Database</td><td>Logical Name</td><td>Size (MB)</td><td>Previous Size</td><td>% Change</td></tr>");
                 for (Map<String, Object> row : maps)
                 {
-                    Long size = Long.parseLong(row.get("size").toString());
+                    long size = Long.parseLong(row.get("size").toString());
                     String key = row.get("LogicalName").toString();
 
-                    newValueMap.put(key, size.toString());
+                    newValueMap.put(key, Long.toString(size));
                     Long previousValue = null;
                     if (oldValueMap != null && oldValueMap.has(key))
                     {
@@ -575,7 +575,7 @@ public class SiteSummaryNotification implements Notification
                 }
                 msg.append("</table>");
 
-                if (newValueMap.size() > 0)
+                if (!newValueMap.isEmpty())
                     toSave.put(dbSizes, new JSONObject(newValueMap).toString());
             }
         }
@@ -632,7 +632,7 @@ public class SiteSummaryNotification implements Notification
             if (ld != null)
                 msg.append("<tr><td>" + ld.getName() + "</td><td>" + ld.getContainer().getPath() + "</td><td>" + NumberFormat.getInstance().format(entry.getValue()) + "</td><td>" + (previousValue == null ? "" : NumberFormat.getInstance().format(previousValue)) + "</td>" + pctChange + "</tr>");
 
-            if (newValueMap.size() > 0)
+            if (!newValueMap.isEmpty())
                 toSave.put(listSizes, new JSONObject(newValueMap).toString());
         }
 
@@ -692,7 +692,7 @@ public class SiteSummaryNotification implements Notification
         msg.append("<br><b>Assay Summary:</b><br><br>");
         msg.append("<table border=1 style='border-collapse: collapse;'><tr style='font-weight:bold;'><td>Provider</td><td>Protocol</td><td>Container Path</td><td># Runs</td><td># Results</td><td>Previous Value</td><td>% Change</td></tr>");
 
-        Map<String, String> newValueMap = new HashMap<String, String>();
+        Map<String, String> newValueMap = new HashMap<>();
         JSONObject oldValueMap = saved.containsKey(assayResultSize) ? new JSONObject(saved.get(assayResultSize)) : null;
 
         for (String ap : providerMap.keySet())
@@ -716,7 +716,7 @@ public class SiteSummaryNotification implements Notification
         }
         msg.append("</table><br>");
 
-        if (newValueMap.size() > 0)
+        if (!newValueMap.isEmpty())
             toSave.put(assayResultSize, new JSONObject(newValueMap).toString());
     }
 }

--- a/LDK/src/org/labkey/ldk/query/DefaultTableCustomizer.java
+++ b/LDK/src/org/labkey/ldk/query/DefaultTableCustomizer.java
@@ -48,7 +48,6 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -125,7 +124,7 @@ public class DefaultTableCustomizer implements TableCustomizer
         assert queryName != null;
 
         List<String> keyFields = ti.getPkColumnNames();
-        assert keyFields.size() > 0 : "No key fields found for the table: " + ti.getPublicSchemaName() + "." + ti.getPublicName();
+        assert !keyFields.isEmpty() : "No key fields found for the table: " + ti.getPublicSchemaName() + "." + ti.getPublicName();
         if (keyFields.size() != 1)
         {
             _log.error("Table: " + ti.getUserSchema().getSchemaName() + "." + ti.getPublicName() + " has more than 1 PK: " + StringUtils.join(keyFields, ";") + ", cannot apply custom links - please update the TableCustomizer properties");
@@ -159,14 +158,14 @@ public class DefaultTableCustomizer implements TableCustomizer
             assert queryName != null;
 
             List<String> keyFields = ti.getPkColumnNames();
-            assert keyFields.size() > 0 : "No key fields found for the table: " + ti.getPublicSchemaName() + "." + ti.getPublicName();
+            assert !keyFields.isEmpty() : "No key fields found for the table: " + ti.getPublicSchemaName() + "." + ti.getPublicName();
             if (keyFields.size() != 1)
             {
                 _log.error("Table: " + schemaName + "." + queryName + " has more than 1 PK: " + StringUtils.join(keyFields, ";") + ", cannot apply custom links - please update the TableCustomizer properties");
                 return;
             }
 
-            if (schemaName != null && queryName != null && keyFields.size() > 0)
+            if (schemaName != null && queryName != null && !keyFields.isEmpty())
             {
                 String keyField = keyFields.get(0);
                 if (!AbstractTableInfo.LINK_DISABLER_ACTION_URL.equals(ti.getImportDataURL(ti.getUserSchema().getContainer())))
@@ -393,7 +392,7 @@ public class DefaultTableCustomizer implements TableCustomizer
         if (moreActionsBtn == null)
         {
             //abort if there are no custom buttons
-            if (buttons.size() == 0)
+            if (buttons.isEmpty())
                 return false;
 
             moreActionsBtn = new UserDefinedButtonConfig();

--- a/LDK/src/org/labkey/ldk/query/LookupSetTable.java
+++ b/LDK/src/org/labkey/ldk/query/LookupSetTable.java
@@ -37,7 +37,6 @@ import org.labkey.ldk.LDKModule;
 import org.labkey.ldk.LDKSchema;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/LDK/src/org/labkey/ldk/query/LookupValidationHelper.java
+++ b/LDK/src/org/labkey/ldk/query/LookupValidationHelper.java
@@ -42,8 +42,8 @@ public class LookupValidationHelper
     private final TableInfo _table;
     private static final Logger _log = LogManager.getLogger(LookupValidationHelper.class);
 
-    private final Map<String, UserSchema> _userSchemaMap = new HashMap<String, UserSchema>();
-    private final Map<String, Map<String, String>> _allowableValueMap = new HashMap<String, Map<String, String>>();
+    private final Map<String, UserSchema> _userSchemaMap = new HashMap<>();
+    private final Map<String, Map<String, String>> _allowableValueMap = new HashMap<>();
 
     private LookupValidationHelper(String containerId, int userId, String schemaName, String queryName)
     {

--- a/LDK/src/org/labkey/ldk/query/UniqueConstraintHelper.java
+++ b/LDK/src/org/labkey/ldk/query/UniqueConstraintHelper.java
@@ -17,9 +17,7 @@ import org.labkey.api.util.MemTracker;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
 

--- a/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
+++ b/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
@@ -303,7 +303,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         checkDate("3/5/99", dateFormat3);
 
         String clientFormattedString = (String)executeScript("return Ext4.Date.format(LDK.ConvertUtils.parseDate('2024-01-01', 'c'), 'Y-m-d');");
-        assertEquals("Incorrect date parsing", clientFormattedString, "2024-01-01");
+        assertEquals("Incorrect date parsing", "2024-01-01", clientFormattedString);
     }
 
     private void checkDate(String dateStr, String javaFormatStr) throws ParseException
@@ -329,7 +329,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         Connection cn = WebTestHelper.getRemoteApiConnection();
 
         //do cleanup in case test is started in the middle
-        Integer highestWorkbookId = deleteExistingWorkbooks();
+        int highestWorkbookId = deleteExistingWorkbooks();
 
         List<CreateContainerResponse> workbooks = new ArrayList<>();
         workbooks.add(_apiContainerHelper.createWorkbook(getProjectName(), "Workbook1", null));
@@ -1466,8 +1466,8 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         int colIdx = dr.getColumnIndex("comment");
         String comment1 = dr.getDataAsText(1, colIdx);
         String comment2 = dr.getDataAsText(2, colIdx);
-        Assert.assertEquals(comment1, comment);
-        Assert.assertEquals(comment2, comment);
+        Assert.assertEquals(comment, comment1);
+        Assert.assertEquals(comment, comment2);
 
         dr.uncheckAllOnPage();
         assertEquals("incorrect number of rows selected", 0, dr.getCheckedCount(this));
@@ -1480,8 +1480,8 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         dr = new DataRegionTable.DataRegionFinder(getDriver()).withName("query").find();
         String comment1b = dr.getDataAsText(1, colIdx);
         String comment2b = dr.getDataAsText(2, colIdx);
-        Assert.assertEquals(comment1b, comment + "\nThis should append to the end");
-        Assert.assertEquals(comment2b, comment);
+        Assert.assertEquals(comment + "\nThis should append to the end", comment1b);
+        Assert.assertEquals(comment, comment2b);
 
         refresh();
         dr = new DataRegionTable.DataRegionFinder(getDriver()).withName("query").find();
@@ -1502,7 +1502,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
 
         // Debug date parsing
         String clientFormattedString = (String)executeScript("return Ext4.Date.format(LDK.ConvertUtils.parseDate('2017-01-02'), 'Y-m-d');");
-        assertEquals("Incorrect date parsing", clientFormattedString, "2017-01-02");
+        assertEquals("Incorrect date parsing", "2017-01-02", clientFormattedString);
 
         waitAndClickAndWait(Ext4Helper.Locators.ext4Button("Submit"));
 
@@ -1572,13 +1572,13 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
 
         //insert dummy data:
         String[] workbookIds = new String[3];
-        Integer i = 0;
+        int i = 0;
         int max = 3;
         while (i < max)
         {
             String id = _helper.createWorkbook(getProjectName(), "Workbook" + i, "Description");
             workbookIds[i] = id;
-            insertDummySampleRow(i.toString());
+            insertDummySampleRow(Integer.toString(i));
             i++;
         }
 

--- a/LDK/test/src/org/labkey/test/util/external/labModules/LabModuleHelper.java
+++ b/LDK/test/src/org/labkey/test/util/external/labModules/LabModuleHelper.java
@@ -23,7 +23,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
-import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.UIAssayHelper;
 import org.labkey.test.util.ext4cmp.Ext4CmpRef;
 import org.labkey.test.util.ext4cmp.Ext4ComboRef;
@@ -95,7 +94,7 @@ public class LabModuleHelper
     {
         Locator l = getNavPanelItem(label, itemText);
         _test.waitForElement(l);
-        Assert.assertEquals("Incorrect number of elements: " + label + "/" + itemText, l.findElements(_test.getDriver()).size(), 1);
+        Assert.assertEquals("Incorrect number of elements: " + label + "/" + itemText, 1, l.findElements(_test.getDriver()).size());
 
         _test.waitAndClick(l);
     }
@@ -417,7 +416,7 @@ public class LabModuleHelper
         if (name == null)
             return null;
 
-        if (name.length() == 0)
+        if (name.isEmpty())
             return null;
 
         StringBuilder buf = new StringBuilder(name.length());

--- a/laboratory/api-src/org/labkey/api/laboratory/AbstractUrlNavItem.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/AbstractUrlNavItem.java
@@ -28,8 +28,8 @@ import org.labkey.api.view.ActionURL;
  */
 abstract public class AbstractUrlNavItem extends AbstractNavItem
 {
-    protected String _labelText = null;
-    protected String _itemText = null;
+    protected String _labelText;
+    protected String _itemText;
     protected DetailsURL _detailsURL = null;
     protected String _staticURL = null;
 

--- a/laboratory/api-src/org/labkey/api/laboratory/LaboratoryService.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/LaboratoryService.java
@@ -123,7 +123,7 @@ abstract public class LaboratoryService
 
     abstract public @Nullable DemographicsProvider getDemographicsProviderByName(Container c, User u, String name);
 
-    public static enum NavItemCategory
+    public enum NavItemCategory
     {
         samples(),
         misc(),

--- a/laboratory/api-src/org/labkey/api/laboratory/StaticURLNavItem.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/StaticURLNavItem.java
@@ -15,8 +15,6 @@
  */
 package org.labkey.api.laboratory;
 
-import org.labkey.api.query.DetailsURL;
-
 /**
  * User: bimber
  * Date: 11/21/12

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/AbstractAssayDataProvider.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/AbstractAssayDataProvider.java
@@ -173,7 +173,7 @@ abstract public class AbstractAssayDataProvider extends AbstractDataProvider imp
         if (props.containsKey(getDefaultMethodPropertyKey(protocolId)))
             return props.get(getDefaultMethodPropertyKey(protocolId));
         else
-            return _importMethods.size() == 0 ?  null : _importMethods.iterator().next().getName();
+            return _importMethods.isEmpty() ?  null : _importMethods.iterator().next().getName();
     }
 
     private String getDefaultMethodPropertyKey(int protocolId)
@@ -263,7 +263,7 @@ abstract public class AbstractAssayDataProvider extends AbstractDataProvider imp
             {
                 List<QueryException> errors = new ArrayList<>();
                 TableInfo query = qd.getTable(errors, true);
-                if (query == null || errors.size() > 0)
+                if (query == null || !errors.isEmpty())
                 {
                     _log.error("Unable to create table for query: " + qd.getSchema().getName() + "/" + qd.getName() + ", in container: " + qd.getContainer().getPath());
                     for (QueryException error : errors)
@@ -305,7 +305,7 @@ abstract public class AbstractAssayDataProvider extends AbstractDataProvider imp
             {
                 List<QueryException> errors = new ArrayList<>();
                 TableInfo query = qd.getTable(errors, true);
-                if (query == null || errors.size() > 0)
+                if (query == null || !errors.isEmpty())
                 {
                     _log.error("Unable to create table for query: " + qd.getSchema().getName() + "/" + qd.getName() + ", in container: " + qd.getContainer().getPath());
                     for (QueryException error : errors)

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/AssayDataProvider.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/AssayDataProvider.java
@@ -36,28 +36,26 @@ import java.util.List;
  */
 public interface AssayDataProvider extends DataProvider
 {
-    abstract public String getProviderName();
+    String getProviderName();
 
-    abstract public AssayProvider getAssayProvider();
+    AssayProvider getAssayProvider();
 
     /**
      * Returns the set of AssayImportMethods supported by this assay.  If none are provided, a default import method
      * will be used
-     * @return
      */
-    abstract public Collection<AssayImportMethod> getImportMethods();
+    Collection<AssayImportMethod> getImportMethods();
 
     /**
      * Return true if this import pathway can be used with assay run templates, which allows runs to be prepared ahead of importing results
-     * @return
      */
-    public boolean supportsRunTemplates();
+    boolean supportsRunTemplates();
 
-    public List<ExpProtocol> getProtocols(Container c);
+    List<ExpProtocol> getProtocols(Container c);
 
-    abstract public AssayImportMethod getImportMethodByName(String methodName);
+    AssayImportMethod getImportMethodByName(String methodName);
 
-    abstract public String getDefaultImportMethodName(Container c, User u, int protocolId);
+    String getDefaultImportMethodName(Container c, User u, int protocolId);
 
-    abstract public boolean isModuleEnabled(Container c);
+    boolean isModuleEnabled(Container c);
 }

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/AssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/AssayParser.java
@@ -36,14 +36,14 @@ public interface AssayParser
     /**
      * Parses the provided file and json object, returning a list of row maps.
      */
-    public JSONObject getPreview(JSONObject json, File file, String fileName, ViewContext ctx) throws BatchValidationException;
+    JSONObject getPreview(JSONObject json, File file, String fileName, ViewContext ctx) throws BatchValidationException;
 
     /**
      * Parses the provided file and json object using getPreview(), then saves this to the database
      */
-    public Pair<ExpExperiment, ExpRun> saveBatch(JSONObject json, File file, String fileName, ViewContext ctx) throws BatchValidationException;
+    Pair<ExpExperiment, ExpRun> saveBatch(JSONObject json, File file, String fileName, ViewContext ctx) throws BatchValidationException;
 
-    public ExpProtocol getProtocol();
+    ExpProtocol getProtocol();
 
-    public AssayProvider getProvider();
+    AssayProvider getProvider();
 }

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayImportMethod.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayImportMethod.java
@@ -326,7 +326,7 @@ public class DefaultAssayImportMethod implements AssayImportMethod
         TableSelector ts = new TableSelector(ti, new SimpleFilter(FieldKey.fromString("plate"), 1), null);
 
         final Map<Object, Object> wellMap = new HashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -72,7 +72,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -120,7 +119,7 @@ public class DefaultAssayParser implements AssayParser
             if (!seen.contains(pd))
             {
                 String description = pd.getDescription();
-                if (description != null && description.length() > 0)
+                if (description != null && !description.isEmpty())
                     map.put(description.toLowerCase(), pd);
                 seen.add(pd);
             }
@@ -309,7 +308,6 @@ public class DefaultAssayParser implements AssayParser
     /**
      * Reads the raw input file and converts it to a regular TSV file before passing to TabLoader
      * This allows subclasses to transform the input data
-     * @return
      */
     protected String readRawFile(ImportContext context) throws BatchValidationException
     {
@@ -330,7 +328,7 @@ public class DefaultAssayParser implements AssayParser
                 }
 
                 if (!StringUtils.isEmpty(StringUtils.join(line)))
-                    out.writeNext(line.toArray(new String[line.size()]));
+                    out.writeNext(line.toArray(new String[0]));
             }
 
             return sw.toString();
@@ -417,7 +415,6 @@ public class DefaultAssayParser implements AssayParser
 
     /**
      * Override this method to provide custom processing of each result row provided as JSON
-     * @return
      */
     protected List<Map<String, Object>> processRowsFromJson(List<Map<String, Object>> rows, ImportContext context)
     {
@@ -641,7 +638,7 @@ public class DefaultAssayParser implements AssayParser
             {
                 JSONArray arr = ExcelFactory.convertExcelToJSON(file, true);
                 List<List<String>> ret = new ArrayList<>();
-                if (arr.length() == 0)
+                if (arr.isEmpty())
                     return ret;
 
                 JSONObject sheet = arr.getJSONObject(0);

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingAssayParser.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.laboratory.assay;
 
-import au.com.bytecode.opencsv.CSVReader;
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -25,10 +24,8 @@ import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.Pair;
 
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +56,7 @@ public class PivotingAssayParser extends DefaultAssayParser
             DomainProperty valueCol = _pivotMethod.getValueColumn(_protocol);
             DomainProperty pivotCol = _pivotMethod.getPivotColumn(_protocol);
             Map<Integer, String> resultCols = null;
-            Integer rowIdx = 0;
+            int rowIdx = 0;
 
             for (List<String> line : getFileLines(context.getFile()))
             {
@@ -93,8 +90,8 @@ public class PivotingAssayParser extends DefaultAssayParser
                         row.addAll(rowBase);
                         row.add(pair.first);
                         row.add(pair.second);
-                        row.add(rowIdx.toString());
-                        out.writeNext(row.toArray(new String[row.size()]));
+                        row.add(Integer.toString(rowIdx));
+                        out.writeNext(row.toArray(new String[0]));
                     }
                 }
                 else
@@ -104,7 +101,7 @@ public class PivotingAssayParser extends DefaultAssayParser
                     row.add(pivotCol.getLabel());
                     row.add(valueCol.getLabel());
                     row.add("_rowIdx");
-                    out.writeNext(row.toArray(new String[row.size()]));
+                    out.writeNext(row.toArray(new String[0]));
                 }
 
                 rowIdx++;
@@ -126,7 +123,7 @@ public class PivotingAssayParser extends DefaultAssayParser
     private Map<Integer, String> inspectHeader(List<String> header, ImportContext context) throws BatchValidationException
     {
         Map<Integer, String> resultMap = new HashMap<>();
-        Map<String, String> allowable = new CaseInsensitiveHashMap<String>();
+        Map<String, String> allowable = new CaseInsensitiveHashMap<>();
         BatchValidationException errors = new BatchValidationException();
 
         for (String val : _pivotMethod.getAllowableValues())

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingImportMethod.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingImportMethod.java
@@ -40,8 +40,8 @@ abstract public class PivotingImportMethod extends DefaultAssayImportMethod
     protected AssayImportMethod _importMethod;
     protected String _pivotField;
     protected String _valueField;
-    protected TableInfo _sourceTable = null;
-    protected String _sourceColumn = null;
+    protected TableInfo _sourceTable;
+    protected String _sourceColumn;
 
     public PivotingImportMethod(AssayImportMethod method, String pivotField, String valueField, TableInfo sourceTable, String sourceColumn)
     {

--- a/laboratory/api-src/org/labkey/api/laboratory/query/ContainerIncrementingTable.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/query/ContainerIncrementingTable.java
@@ -94,7 +94,7 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
         @Override
         protected Map<String, Object> insertRow(User user, Container container, Map<String, Object> row) throws DuplicateKeyException, ValidationException, QueryUpdateServiceException, SQLException
         {
-            Integer rowId = null;
+            Integer rowId;
             boolean hasSelfAssignedId = false;
             // This idea here is that the majority of the time the ID will auto-increment within this container (defined as parent + workbooks)
             // however, there is a backdoor that lets the IDs get set manually.  An example of this would be when a row was deleted accidentally or otherwise, and you want
@@ -279,7 +279,7 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
                 }
             };
 
-            final Map<String, Integer> inputColMap = new HashMap<String, Integer>();
+            final Map<String, Integer> inputColMap = new HashMap<>();
             for (int idx = 1; idx <= input.getColumnCount(); idx++)
             {
                 ColumnInfo col = input.getColumnInfo(idx);
@@ -356,8 +356,8 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
      */
     private class IncrementIdGenerator
     {
-        private final Map<Container, Integer> _idMap = new HashMap<Container, Integer>();
-        private final Map<Container, Set<Integer>> _existingIdsMap = new HashMap<Container, Set<Integer>>();
+        private final Map<Container, Integer> _idMap = new HashMap<>();
+        private final Map<Container, Set<Integer>> _existingIdsMap = new HashMap<>();
 
         public IncrementIdGenerator()
         {
@@ -409,7 +409,7 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
 
             Set<Integer> set = _existingIdsMap.get(target);
             if (set == null)
-                set = new HashSet<Integer>();
+                set = new HashSet<>();
 
             //if we have already tested this ID, it is assumed to exist
             if (set.contains(rowId))

--- a/laboratory/src/org/labkey/laboratory/ExtraDataSourcesDataProvider.java
+++ b/laboratory/src/org/labkey/laboratory/ExtraDataSourcesDataProvider.java
@@ -208,7 +208,7 @@ public class ExtraDataSourcesDataProvider extends AbstractDataProvider
     @Override
     public List<NavItem> getSubjectIdSummary(Container c, User u, String subjectId)
     {
-        List<NavItem> items = new ArrayList<NavItem>();
+        List<NavItem> items = new ArrayList<>();
 
         LaboratoryServiceImpl service = LaboratoryServiceImpl.get();
         Set<AdditionalDataSource> sources = service.getAdditionalDataSources(c, u);
@@ -239,7 +239,7 @@ public class ExtraDataSourcesDataProvider extends AbstractDataProvider
         {
             if (owner instanceof ReportItem sq)
             {
-                QueryCache cache = ((ReportItem) owner).getQueryCache();
+                QueryCache cache = sq.getQueryCache();
                 TabbedReportItem reportItem = new QueryTabbedReportItem(cache, this, sq.getSchema(), sq.getQuery(), sq.getLabel(), owner.getReportCategory());
                 if (sq.getTargetContainer(c) != null)
                     reportItem.setTargetContainer(sq.getTargetContainer(c));

--- a/laboratory/src/org/labkey/laboratory/LaboratoryContainerListener.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryContainerListener.java
@@ -13,7 +13,6 @@ import org.labkey.api.data.TableSelector;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.SimpleModuleContainerListener;
-import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;

--- a/laboratory/src/org/labkey/laboratory/LaboratoryController.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryController.java
@@ -117,7 +117,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class PrepareExptRunAction extends SimpleViewAction<PlanExptRunForm>
+    public static class PrepareExptRunAction extends SimpleViewAction<PlanExptRunForm>
     {
         @Override
         public ModelAndView getView(PlanExptRunForm form, BindException errors) throws Exception
@@ -154,7 +154,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class EnsureIndexesAction extends ConfirmAction<Object>
+    public static class EnsureIndexesAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -206,7 +206,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class EnsureAssayFieldsAction extends ConfirmAction<EnsureAssayFieldsForm>
+    public static class EnsureAssayFieldsAction extends ConfirmAction<EnsureAssayFieldsForm>
     {
         @Override
         public void validateCommand(EnsureAssayFieldsForm form, Errors errors)
@@ -296,7 +296,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class SetTableIncrementValueAction extends ConfirmAction<SetTableIncrementForm>
+    public static class SetTableIncrementValueAction extends ConfirmAction<SetTableIncrementForm>
     {
         @Override
         public void validateCommand(SetTableIncrementForm form, Errors errors)
@@ -455,7 +455,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class InitWorkbooksAction extends ConfirmAction<Object>
+    public static class InitWorkbooksAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -494,7 +494,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class InitContainerIncrementingTableAction extends ConfirmAction<SetTableIncrementForm>
+    public static class InitContainerIncrementingTableAction extends ConfirmAction<SetTableIncrementForm>
     {
         @Override
         public void validateCommand(SetTableIncrementForm form, Errors errors)
@@ -566,7 +566,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ResetLaboratoryFoldersAction extends ConfirmAction<Object>
+    public static class ResetLaboratoryFoldersAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -605,7 +605,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class ProcessAssayDataAction extends AbstractFileUploadAction<ProcessAssayForm>
+    public static class ProcessAssayDataAction extends AbstractFileUploadAction<ProcessAssayForm>
     {
         @Override
         protected void setContentType(HttpServletResponse response)
@@ -698,7 +698,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(AdminPermission.class)
-    public class PopulateDefaultsAction extends MutatingApiAction<PopulateDefaultsForm>
+    public static class PopulateDefaultsAction extends MutatingApiAction<PopulateDefaultsForm>
     {
         @Override
         public ApiResponse execute(PopulateDefaultsForm form, BindException errors) throws Exception
@@ -737,7 +737,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class UpdateWorkbookAction extends MutatingApiAction<UpdateWorkbookForm>
+    public static class UpdateWorkbookAction extends MutatingApiAction<UpdateWorkbookForm>
     {
         @Override
         public ApiResponse execute(UpdateWorkbookForm form, BindException errors) throws Exception
@@ -776,7 +776,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDemographicsProvidersAction extends ReadOnlyApiAction<Object>
+    public static class GetDemographicsProvidersAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors) throws Exception
@@ -803,7 +803,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class UpdateWorkbookTagsAction extends MutatingApiAction<UpdateWorkbookForm>
+    public static class UpdateWorkbookTagsAction extends MutatingApiAction<UpdateWorkbookForm>
     {
         @Override
         public ApiResponse execute(UpdateWorkbookForm form, BindException errors) throws Exception
@@ -918,7 +918,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(UpdatePermission.class)
-    public class SaveTemplateAction extends MutatingApiAction<SaveTemplateForm>
+    public static class SaveTemplateAction extends MutatingApiAction<SaveTemplateForm>
     {
         @Override
         public ApiResponse execute(SaveTemplateForm form, BindException errors) throws Exception
@@ -1036,7 +1036,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class CreateTemplateAction extends ExportAction<ProcessAssayForm>
+    public static class CreateTemplateAction extends ExportAction<ProcessAssayForm>
     {
         @Override
         public void validate(ProcessAssayForm form, BindException errors)
@@ -1103,7 +1103,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDemographicsSourcesAction extends ReadOnlyApiAction<DataSourcesForm>
+    public static class GetDemographicsSourcesAction extends ReadOnlyApiAction<DataSourcesForm>
     {
         @Override
         public ApiResponse execute(DataSourcesForm form, BindException errors)
@@ -1150,7 +1150,7 @@ public class LaboratoryController extends SpringActionController
                 if (getUser().hasSiteAdminPermission())
                 {
                     Map<Container, Set<DemographicsSource>> map = service.getAllDemographicsSources(getUser());
-                    Map<String, JSONArray> siteSummary = new HashMap<String, JSONArray>();
+                    Map<String, JSONArray> siteSummary = new HashMap<>();
                     for (Container c : map.keySet())
                     {
                         JSONArray arr = siteSummary.get(c.getPath());
@@ -1180,7 +1180,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetAdditionalDataSourcesAction extends ReadOnlyApiAction<DataSourcesForm>
+    public static class GetAdditionalDataSourcesAction extends ReadOnlyApiAction<DataSourcesForm>
     {
         @Override
         public ApiResponse execute(DataSourcesForm form, BindException errors)
@@ -1227,7 +1227,7 @@ public class LaboratoryController extends SpringActionController
                 if (getUser().hasSiteAdminPermission())
                 {
                     Map<Container, Set<AdditionalDataSource>> map = service.getAllAdditionalDataSources(getUser());
-                    Map<String, JSONArray> siteSummary = new HashMap<String, JSONArray>();
+                    Map<String, JSONArray> siteSummary = new HashMap<>();
                     for (Container c : map.keySet())
                     {
                         JSONArray arr = siteSummary.get(c.getPath());
@@ -1299,7 +1299,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(LaboratoryAdminPermission.class)
-    public class SetDemographicsSourcesAction extends MutatingApiAction<SetDataSourcesForm>
+    public static class SetDemographicsSourcesAction extends MutatingApiAction<SetDataSourcesForm>
     {
         @Override
         public ApiResponse execute(SetDataSourcesForm form, BindException errors)
@@ -1320,7 +1320,7 @@ public class LaboratoryController extends SpringActionController
                 return null;
             }
 
-            Set<DemographicsSource> sources = new HashSet<DemographicsSource>();
+            Set<DemographicsSource> sources = new HashSet<>();
 
             JSONArray json = new JSONArray(form.getTables());
             for (JSONObject obj : JsonUtil.toJSONObjectList(json))
@@ -1383,7 +1383,7 @@ public class LaboratoryController extends SpringActionController
                 return null;
             }
 
-            Set<AdditionalDataSource> sources = new HashSet<AdditionalDataSource>();
+            Set<AdditionalDataSource> sources = new HashSet<>();
 
             JSONArray json = new JSONArray(form.getTables());
             for (JSONObject obj : JsonUtil.toJSONObjectList(json))
@@ -1444,7 +1444,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(LaboratoryAdminPermission.class)
-    public class SetUrlDataSourcesAction extends MutatingApiAction<SetUrlDataSourcesForm>
+    public static class SetUrlDataSourcesAction extends MutatingApiAction<SetUrlDataSourcesForm>
     {
         @Override
         public ApiResponse execute(SetUrlDataSourcesForm form, BindException errors)
@@ -1465,7 +1465,7 @@ public class LaboratoryController extends SpringActionController
                 return null;
             }
 
-            Set<URLDataSource> sources = new HashSet<URLDataSource>();
+            Set<URLDataSource> sources = new HashSet<>();
 
             JSONArray json = new JSONArray(form.getSources());
             for (JSONObject obj : JsonUtil.toJSONObjectList(json))
@@ -1500,7 +1500,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetAssayImportHeadersAction extends ReadOnlyApiAction<AssayImportHeadersForm>
+    public static class GetAssayImportHeadersAction extends ReadOnlyApiAction<AssayImportHeadersForm>
     {
         @Override
         public ApiResponse execute(AssayImportHeadersForm form, BindException errors)
@@ -1583,7 +1583,7 @@ public class LaboratoryController extends SpringActionController
                 map.put(key, json.get(key) == null ? null : String.valueOf(json.get(key)));
             }
 
-            if (toActivate.size() > 0)
+            if (!toActivate.isEmpty())
             {
                 toActivate.addAll(activeModules);
                 getContainer().setActiveModules(toActivate);
@@ -1598,7 +1598,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(LaboratoryAdminPermission.class)
-    public class SetItemDefaultViewAction extends MutatingApiAction<JsonDataForm>
+    public static class SetItemDefaultViewAction extends MutatingApiAction<JsonDataForm>
     {
         @Override
         public ApiResponse execute(JsonDataForm form, BindException errors)
@@ -1632,7 +1632,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(LaboratoryAdminPermission.class)
-    public class SetDataBrowserSettingsAction extends MutatingApiAction<JsonDataForm>
+    public static class SetDataBrowserSettingsAction extends MutatingApiAction<JsonDataForm>
     {
         @Override
         public ApiResponse execute(JsonDataForm form, BindException errors)
@@ -1653,7 +1653,7 @@ public class LaboratoryController extends SpringActionController
             WritablePropertyMap propMap = PropertyManager.getWritableProperties(getContainer(), TabbedReportItem.OVERRIDES_PROP_KEY, true);
 
             List<TabbedReportItem> tabbedReports = LaboratoryService.get().getTabbedReportItems(getContainer(), getUser());
-            Map<String, TabbedReportItem> reportMap = new HashMap<String, TabbedReportItem>();
+            Map<String, TabbedReportItem> reportMap = new HashMap<>();
             for (TabbedReportItem item : tabbedReports)
             {
                 reportMap.put(TabbedReportItem.getOverridesPropertyKey(item), item);
@@ -1678,7 +1678,7 @@ public class LaboratoryController extends SpringActionController
                 if (reportCategory != null && !ti.getReportCategory().equals(reportCategory))
                     toSave.put("reportCategory", reportCategory);
 
-                if (toSave.keySet().size() > 0)
+                if (!toSave.keySet().isEmpty())
                     propMap.put(key, toSave.toString());
                 else propMap.remove(key);
             }
@@ -1692,7 +1692,7 @@ public class LaboratoryController extends SpringActionController
 
 
     @RequiresPermission(LaboratoryAdminPermission.class)
-    public class SaveAssayDefaultsAction extends MutatingApiAction<JsonDataForm>
+    public static class SaveAssayDefaultsAction extends MutatingApiAction<JsonDataForm>
     {
         @Override
         public ApiResponse execute(JsonDataForm form, BindException errors)
@@ -1725,7 +1725,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDataItemsAction extends MutatingApiAction<GetDataItemsForm>
+    public static class GetDataItemsAction extends MutatingApiAction<GetDataItemsForm>
     {
         @Override
         public ApiResponse execute(GetDataItemsForm form, BindException errors)
@@ -1825,7 +1825,7 @@ public class LaboratoryController extends SpringActionController
                     Set<Module> active = getContainer().getActiveModules();
                     if (!active.contains(m))
                     {
-                        Set<Module> newActive = new HashSet<Module>();
+                        Set<Module> newActive = new HashSet<>();
                         newActive.addAll(active);
                         newActive.add(m);
 
@@ -1840,7 +1840,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetImportMethodsAction extends ReadOnlyApiAction<ImportMethodsForm>
+    public static class GetImportMethodsAction extends ReadOnlyApiAction<ImportMethodsForm>
     {
         @Override
         public ApiResponse execute(ImportMethodsForm form, BindException errors)
@@ -1874,7 +1874,7 @@ public class LaboratoryController extends SpringActionController
                 JSONObject json = new JSONObject();
                 AssayDataProvider adp = LaboratoryService.get().getDataProviderForAssay(provider);
                 List<ExpProtocol> protocolsForProvider = new ArrayList<>();
-                if (protocols.size() == 0)
+                if (protocols.isEmpty())
                     protocolsForProvider.addAll(adp.getProtocols(getContainer()));
                 else
                     protocolsForProvider.addAll(protocols);
@@ -1910,7 +1910,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDataSummaryAction extends ReadOnlyApiAction<DataSummaryForm>
+    public static class GetDataSummaryAction extends ReadOnlyApiAction<DataSummaryForm>
     {
         @Override
         public ApiResponse execute(DataSummaryForm form, BindException errors)
@@ -1959,7 +1959,7 @@ public class LaboratoryController extends SpringActionController
 
             for (String key : items.keySet())
             {
-                List<JSONObject> jsonItems = new ArrayList<JSONObject>();
+                List<JSONObject> jsonItems = new ArrayList<>();
                 for (NavItem item : items.get(key))
                 {
                     jsonItems.add(item.toJSON(getContainer(), getUser()));
@@ -1987,7 +1987,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetSubjectIdSummaryAction extends ReadOnlyApiAction<SubjectSummaryForm>
+    public static class GetSubjectIdSummaryAction extends ReadOnlyApiAction<SubjectSummaryForm>
     {
         @Override
         public ApiResponse execute(SubjectSummaryForm form, BindException errors)
@@ -2249,7 +2249,7 @@ public class LaboratoryController extends SpringActionController
             if (ti == null)
                 return null;
             List<String> pks = ti.getPkColumnNames();
-            if (pks.size() == 0)
+            if (pks.isEmpty())
                 return null;
 
             ActionURL url = new ActionURL("query", "importData", c);
@@ -2330,7 +2330,7 @@ public class LaboratoryController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DataBrowserAction extends SimpleViewAction<Object>
+    public static class DataBrowserAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object form, BindException errors) throws Exception

--- a/laboratory/src/org/labkey/laboratory/LaboratoryDataProvider.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryDataProvider.java
@@ -162,7 +162,7 @@ public class LaboratoryDataProvider extends AbstractDataProvider
     @Override
     public List<NavItem> getSettingsItems(Container c, User u)
     {
-        List<NavItem> items = new ArrayList<NavItem>();
+        List<NavItem> items = new ArrayList<>();
         String categoryName = "Samples";
         String general = "General Settings";
         String adminSettings = "Site Administration";

--- a/laboratory/src/org/labkey/laboratory/LaboratoryManager.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryManager.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.assay.AssayProvider;
 import org.labkey.api.assay.AssayService;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -226,7 +225,6 @@ public class LaboratoryManager
 
     /**
      * This is designed to iterate a folder and children, resetting the webparts and tabs
-     * @param c
      */
     public void resetLaboratoryFolderTypes(User u, Container c, boolean includeChildren)
     {
@@ -315,14 +313,14 @@ public class LaboratoryManager
         List<String> toDelete = new ArrayList<>(existingTags);
         toDelete.removeAll(newTags);
 
-        if (toDelete.size() > 0)
+        if (!toDelete.isEmpty())
         {
             SimpleFilter filter1 = new SimpleFilter(FieldKey.fromString("tag"), toDelete, CompareType.IN);
             filter1.addCondition(FieldKey.fromString("container"), c.getId());
             Table.delete(ti, filter1);
         }
 
-        List<String> toAdd = new ArrayList<String>(newTags);
+        List<String> toAdd = new ArrayList<>(newTags);
         toAdd.removeAll(existingTags);
 
         Date created = new Date();
@@ -461,7 +459,7 @@ public class LaboratoryManager
 
         QueryUpdateService qus = ct.getUpdateService();
         String colName = ct.getIncrementingCol();
-        Set<String> toSelect = new HashSet<String>();
+        Set<String> toSelect = new HashSet<>();
         toSelect.add(colName);
         for (String ci : ct.getPkColumnNames())
         {

--- a/laboratory/src/org/labkey/laboratory/LaboratoryUpgradeCode.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryUpgradeCode.java
@@ -57,7 +57,7 @@ public class LaboratoryUpgradeCode implements UpgradeCode
             filter.addCondition(FieldKey.fromString("quantity"), null, CompareType.ISBLANK);
 
             TableSelector ts = new TableSelector(ti, PageFlowUtil.set("rowid", "quantity_string"), filter, null);
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -103,7 +103,7 @@ public class LaboratoryUpgradeCode implements UpgradeCode
         final TableInfo ti = LaboratorySchema.getInstance().getTable(LaboratorySchema.TABLE_WORKBOOKS);
         TableSelector ts = new TableSelector(ti);
         final Map<String, Integer> containerMap = new HashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException

--- a/laboratory/src/org/labkey/laboratory/SampleTypeDataProvider.java
+++ b/laboratory/src/org/labkey/laboratory/SampleTypeDataProvider.java
@@ -77,7 +77,7 @@ public class SampleTypeDataProvider extends AbstractDataProvider
     public List<NavItem> getSampleNavItems(Container c, User u)
     {
         //also append all sample types in this container
-        List<NavItem> navItems = new ArrayList<NavItem>();
+        List<NavItem> navItems = new ArrayList<>();
 
         for (ExpSampleType st : SampleTypeService.get().getSampleTypes(c, u, true))
         {
@@ -130,7 +130,7 @@ public class SampleTypeDataProvider extends AbstractDataProvider
     @Override
     public List<NavItem> getSubjectIdSummary(Container c, User u, String subjectId)
     {
-        List<NavItem> items = new ArrayList<NavItem>();
+        List<NavItem> items = new ArrayList<>();
         for (ExpSampleType st : SampleTypeService.get().getSampleTypes(c, u, true))
         {
             UserSchema us = QueryService.get().getUserSchema(u, c, "Samples");

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -136,7 +136,6 @@ public class AssayHelper
             if (templateId == null)
             {
                 row = Table.insert(u, ti, row);
-                row.get("rowid");
             }
             else
             {

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -126,7 +126,7 @@ public class AssayHelper
             validateTemplate(u, c, protocol, templateId, title, importMethod, json);
 
             TableInfo ti = LaboratorySchema.getInstance().getSchema().getTable(LaboratorySchema.TABLE_ASSAY_RUN_TEMPLATES);
-            Map<String, Object> row = new HashMap<String, Object>();
+            Map<String, Object> row = new HashMap<>();
             row.put("assayId", protocol.getRowId());
             row.put("title", title);
             row.put("importMethod", importMethod);
@@ -136,7 +136,7 @@ public class AssayHelper
             if (templateId == null)
             {
                 row = Table.insert(u, ti, row);
-                templateId = (Integer)row.get("rowid");
+                row.get("rowid");
             }
             else
             {
@@ -287,7 +287,7 @@ public class AssayHelper
 
     public static List<String> ensureAssayFields(User user, String providerName, boolean renameConflictingFields, boolean reportMessagesOnly) throws ChangePropertyDescriptorException
     {
-        List<String> messages = new ArrayList<String>();
+        List<String> messages = new ArrayList<>();
 
         if (!reportMessagesOnly)
             _log.info("Attempting to synchronize columns for all instances of assay: " + providerName);
@@ -299,7 +299,7 @@ public class AssayHelper
             return messages;
         }
 
-        List<ExpProtocol> allProtocols = new ArrayList<ExpProtocol>();
+        List<ExpProtocol> allProtocols = new ArrayList<>();
         Integer[] protocolIds = new TableSelector(ExperimentService.get().getTinfoProtocol(), Collections.singleton("rowid"), null, null).getArray(Integer.class);
         for (Integer protocolId : protocolIds)
         {
@@ -448,7 +448,7 @@ public class AssayHelper
                 CacheManager.clearAllKnownCaches();
             }
 
-            if (messages.size() == 0)
+            if (messages.isEmpty())
             {
                 String msg = "No changes are necessary";
                 messages.add(msg);

--- a/laboratory/src/org/labkey/laboratory/assay/RunUploadContext.java
+++ b/laboratory/src/org/labkey/laboratory/assay/RunUploadContext.java
@@ -82,7 +82,7 @@ public class RunUploadContext<ProviderType extends AssayProvider> implements Ass
         if (_runProperties != null)
         {
             AssayProvider provider = AssayService.get().getProvider(getProtocol());
-            Map<DomainProperty, String> props = new HashMap<DomainProperty, String>();
+            Map<DomainProperty, String> props = new HashMap<>();
 
 
             for (DomainProperty dp : provider.getRunDomain(getProtocol()).getProperties())
@@ -105,7 +105,7 @@ public class RunUploadContext<ProviderType extends AssayProvider> implements Ass
         if (_batchProperties != null)
         {
             AssayProvider provider = AssayService.get().getProvider(getProtocol());
-            Map<DomainProperty, String> props = new HashMap<DomainProperty, String>();
+            Map<DomainProperty, String> props = new HashMap<>();
 
             for (DomainProperty dp : provider.getBatchDomain(getProtocol()).getProperties())
             {

--- a/laboratory/src/org/labkey/laboratory/notification/LabSummaryNotification.java
+++ b/laboratory/src/org/labkey/laboratory/notification/LabSummaryNotification.java
@@ -227,7 +227,7 @@ public class LabSummaryNotification implements Notification
 
         msg.append("</table><p></p><hr>");
 
-        if (newValueMap.size() > 0)
+        if (!newValueMap.isEmpty())
             toSave.put(rowCount, new JSONObject(newValueMap).toString());
     }
 
@@ -273,7 +273,7 @@ public class LabSummaryNotification implements Notification
 
         msg.append("</table><p></p><hr>");
 
-        if (newValueMap.size() > 0)
+        if (!newValueMap.isEmpty())
             toSave.put(rowCount, new JSONObject(newValueMap).toString());
     }
 
@@ -343,9 +343,9 @@ public class LabSummaryNotification implements Notification
         msg.append("</table><br>");
         msg.append("<hr>");
 
-        if (newValueMap.size() > 0)
+        if (!newValueMap.isEmpty())
             toSave.put(fileRootSizes, new JSONObject(newValueMap).toString());
-        if (newValueMapCounts.size() > 0)
+        if (!newValueMapCounts.isEmpty())
             toSave.put(fileRootCounts, new JSONObject(newValueMapCounts).toString());
     }
 }

--- a/laboratory/src/org/labkey/laboratory/query/AssayRunTemplatesCustomizer.java
+++ b/laboratory/src/org/labkey/laboratory/query/AssayRunTemplatesCustomizer.java
@@ -44,7 +44,7 @@ public class AssayRunTemplatesCustomizer implements TableCustomizer
             ati.setUpdateURL(DetailsURL.fromString("/laboratory/prepareExptRun.view?assayId=${assayId}&templateId=${rowid}"));
             ati.setDetailsURL(null);
 
-            List<ColumnInfo> newCols = new ArrayList<ColumnInfo>();
+            List<ColumnInfo> newCols = new ArrayList<>();
 
             ExprColumn completeCol = new ExprColumn(ti, "enter_results", new SQLFragment("'Enter Results'"), JdbcType.VARCHAR, ti.getColumn("assayId"), ti.getColumn("runid"));
             completeCol.setName("enter_results");
@@ -65,7 +65,7 @@ public class AssayRunTemplatesCustomizer implements TableCustomizer
             newCols.addAll(ati.getColumns());
 
             //reset default visible columns on table
-            List<FieldKey> defaultColumns = new ArrayList<FieldKey>();
+            List<FieldKey> defaultColumns = new ArrayList<>();
             defaultColumns.add(completeCol.getFieldKey());
             defaultColumns.addAll(ati.getDefaultVisibleColumns());
             ati.setDefaultVisibleColumns(defaultColumns);

--- a/laboratory/src/org/labkey/laboratory/query/FreezerTriggerHelper.java
+++ b/laboratory/src/org/labkey/laboratory/query/FreezerTriggerHelper.java
@@ -35,7 +35,7 @@ public class FreezerTriggerHelper
     private final User _user;
     private final TableInfo _table;
 
-    private final Map<String, Map<String, Integer>> _cachedRows = new HashMap<String, Map<String, Integer>>();
+    private final Map<String, Map<String, Integer>> _cachedRows = new HashMap<>();
 
     private FreezerTriggerHelper(String containerId, int userId)
     {
@@ -86,7 +86,7 @@ public class FreezerTriggerHelper
 
     public String getKey(String location, String freezer, String cane, String box, String box_row, String box_column)
     {
-        List<String> tokens = new ArrayList<String>();
+        List<String> tokens = new ArrayList<>();
 
         if (!StringUtils.isEmpty(location))
             tokens.add("location: " + location);
@@ -115,8 +115,8 @@ public class FreezerTriggerHelper
 
         TableSelector ts = new TableSelector(_table, PageFlowUtil.set("location", "freezer", "cane", "box", "box_row", "box_column", "rowid"), filter, null);
 
-        final Map<String, Integer> keys = new HashMap<String, Integer>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        final Map<String, Integer> keys = new HashMap<>();
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException

--- a/laboratory/src/org/labkey/laboratory/query/LaboratoryTableCustomizer.java
+++ b/laboratory/src/org/labkey/laboratory/query/LaboratoryTableCustomizer.java
@@ -117,7 +117,7 @@ public class LaboratoryTableCustomizer implements TableCustomizer
         ColumnInfo wrappedContainer = ti.getColumn("workbook");
         if (wrappedContainer != null)
         {
-            List<FieldKey> cols = new ArrayList<FieldKey>();
+            List<FieldKey> cols = new ArrayList<>();
             cols.addAll(ti.getDefaultVisibleColumns());
             if (!cols.contains(wrappedContainer.getFieldKey()))
             {
@@ -141,7 +141,7 @@ public class LaboratoryTableCustomizer implements TableCustomizer
         assert queryName != null;
 
         List<String> keyFields = ti.getPkColumnNames();
-        if (keyFields.size() == 0)
+        if (keyFields.isEmpty())
         {
             _log.error("Table: " + schemaName + "." + queryName + " has no key fields: " + StringUtils.join(keyFields, ";"));
             return;

--- a/laboratory/src/org/labkey/laboratory/query/LaboratoryWorkbooksTable.java
+++ b/laboratory/src/org/labkey/laboratory/query/LaboratoryWorkbooksTable.java
@@ -92,7 +92,7 @@ public class LaboratoryWorkbooksTable extends SimpleUserSchema.SimpleTable
         return new UpdateService(this);
     }
 
-    private class UpdateService extends SimpleQueryUpdateService
+    private static class UpdateService extends SimpleQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {
@@ -111,7 +111,7 @@ public class LaboratoryWorkbooksTable extends SimpleUserSchema.SimpleTable
         {
             if (container.isWorkbook())
             {
-                Integer rowId;
+                int rowId;
                 try
                 {
                     rowId = Integer.parseInt(container.getName());
@@ -201,8 +201,8 @@ public class LaboratoryWorkbooksTable extends SimpleUserSchema.SimpleTable
 
             final SimpleTranslator it = new SimpleTranslator(input, context);
 
-            final Map<String, Integer> inputColMap = new HashMap<String, Integer>();
-            final Map<String, Integer> outputColMap = new HashMap<String, Integer>();
+            final Map<String, Integer> inputColMap = new HashMap<>();
+            final Map<String, Integer> outputColMap = new HashMap<>();
 
             for (int idx = 1; idx <= input.getColumnCount(); idx++)
             {
@@ -314,9 +314,9 @@ public class LaboratoryWorkbooksTable extends SimpleUserSchema.SimpleTable
      * The IDs are determined in LaboratoryManager, but this code will increment them within the rows
      * of a set of incoming records.
      */
-    private class WorkbookIdGenerator
+    private static class WorkbookIdGenerator
     {
-        private final Map<String, Integer> _idMap = new HashMap<String, Integer>();
+        private final Map<String, Integer> _idMap = new HashMap<>();
 
         public WorkbookIdGenerator()
         {

--- a/laboratory/src/org/labkey/laboratory/query/SamplesCustomizer.java
+++ b/laboratory/src/org/labkey/laboratory/query/SamplesCustomizer.java
@@ -54,7 +54,7 @@ public class SamplesCustomizer implements TableCustomizer
             col.setDescription("This field takes the concentration multiplied by the quantity fields.  It is automatically calculated and does not take units or other information into account.");
 
             //inject amount column after quantity.
-            List<ColumnInfo> columns = new ArrayList<ColumnInfo>();
+            List<ColumnInfo> columns = new ArrayList<>();
             columns.addAll(ti.getColumns());
             for (ColumnInfo c : columns)
                 ti.removeColumn(c);

--- a/laboratory/src/org/labkey/laboratory/security/LaboratoryAdminRole.java
+++ b/laboratory/src/org/labkey/laboratory/security/LaboratoryAdminRole.java
@@ -1,16 +1,11 @@
 package org.labkey.laboratory.security;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.laboratory.security.LaboratoryAdminPermission;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.AbstractModuleScopedRole;
-import org.labkey.api.security.roles.AbstractRole;
 import org.labkey.laboratory.LaboratoryModule;
 
 /**

--- a/laboratory/src/org/labkey/laboratory/table/WrappingTableCustomizer.java
+++ b/laboratory/src/org/labkey/laboratory/table/WrappingTableCustomizer.java
@@ -22,7 +22,7 @@ public class WrappingTableCustomizer implements TableCustomizer
     {
         LaboratoryService.get().getLaboratoryTableCustomizer().customize(ti);
 
-        if (ti.getPkColumnNames().size() > 0)
+        if (!ti.getPkColumnNames().isEmpty())
             LDKService.get().getDefaultTableCustomizer().customize(ti);
         else
             LDKService.get().getBuiltInColumnsCustomizer(true).customize(ti);


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


