### PR TITLE
Relocate methods related to file name uniqueness to `FileUtil`

### DIFF
--- a/laboratory/src/org/labkey/laboratory/LaboratoryController.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryController.java
@@ -79,6 +79,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.ErrorRenderer;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.JsonUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.util.URLHelper;
@@ -622,7 +623,7 @@ public class LaboratoryController extends SpringActionController
             try
             {
                 FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(getContainer());
-                return AssayFileWriter.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
+                return FileUtil.findUniqueFileName(filename, targetDirectory).toNioPathForWrite().toFile();
             }
             catch (ExperimentException e)
             {

--- a/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
@@ -52,6 +52,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Pair;
 import org.labkey.api.view.ViewContext;
 import org.labkey.laboratory.assay.AssayHelper;
@@ -201,7 +202,7 @@ public class LaboratoryServiceImpl extends LaboratoryService
         try
         {
             FileLike targetDirectory = AssayFileWriter.ensureUploadDirectory(ctx.getContainer());
-            FileLike file = AssayFileWriter.findUniqueFileName(basename, targetDirectory);
+            FileLike file = FileUtil.findUniqueFileName(basename, targetDirectory);
 
             return this.saveAssayBatch(results, json, file.toNioPathForRead().toFile(), ctx, provider, protocol);
         }


### PR DESCRIPTION
#### Rationale
Since there's nothing specific about assays in the `findUniqueFileName` method (and relatives), they are better located in the `FileUtil` class than `AssayFileWriter`.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6869

#### Changes
* Adjust location for `findUniqueFileName` method.
