### PR TITLE
Update usage queries to reference auditlog.UserAuditEvent

### DIFF
--- a/LDK/resources/queries/core/DistinctUsersByMonth.sql
+++ b/LDK/resources/queries/core/DistinctUsersByMonth.sql
@@ -28,9 +28,9 @@ year(a.date) as year,
 month(a.date) as month,
 a.CreatedBy.DisplayName as user
 
-FROM "/".auditlog.audit a
+FROM "/".auditlog.UserAuditEvent a
 
-WHERE a.EventType = 'UserAuditEvent' AND a.Comment LIKE '%logged in%'
+WHERE a.Comment LIKE '%logged in%'
 
 GROUP BY year(a.date), month(a.date), a.CreatedBy.DisplayName
 

--- a/LDK/resources/queries/core/SiteUsageByDay.sql
+++ b/LDK/resources/queries/core/SiteUsageByDay.sql
@@ -27,8 +27,7 @@ CASE
 END as dayOfWeek,
 count(*) AS Logins
 
-FROM "/".auditlog.audit a
+FROM "/".auditlog.UserAuditEvent a
 
-WHERE a.EventType = 'UserAuditEvent'
-AND a.Comment LIKE '%logged in%'
+WHERE a.Comment LIKE '%logged in%'
 GROUP BY cast(a.date as date)

--- a/LDK/resources/queries/core/SiteUsageByHour.sql
+++ b/LDK/resources/queries/core/SiteUsageByHour.sql
@@ -19,8 +19,8 @@ SELECT
 hour(a.date) as Hour,
 count(*) AS Visits
 
-FROM "/".auditlog.audit a
+FROM "/".auditlog.UserAuditEvent a
 
-WHERE a.EventType = 'UserAuditEvent' AND a.Comment LIKE '%logged in%'
+WHERE a.Comment LIKE '%logged in%'
 
 GROUP BY hour(a.date)

--- a/LDK/resources/queries/core/SiteUsageByMonth.sql
+++ b/LDK/resources/queries/core/SiteUsageByMonth.sql
@@ -20,10 +20,9 @@ month(a.date) as month,
 cast(cast(year(a.date) as varchar) || '-' || cast(month(a.date) as varchar) || '-01' as DATE) as date,
 count(*) AS Logins
 
-FROM "/".auditlog.audit a
+FROM "/".auditlog.UserAuditEvent a
 --FROM audit_pg.auditLog a
 
-WHERE a.EventType = 'UserAuditEvent'
-AND a.Comment LIKE '%logged in%'
+WHERE a.Comment LIKE '%logged in%'
 
 GROUP BY year(a.date), month(a.date)

--- a/LDK/resources/queries/core/SiteUsageByUser.sql
+++ b/LDK/resources/queries/core/SiteUsageByUser.sql
@@ -18,6 +18,6 @@ PARAMETERS(MinDate TIMESTAMP)
 SELECT
 a.CreatedBy,
 COUNT(a.Date) AS LogInCount
-FROM "/".auditlog.audit a
+FROM "/".auditlog.UserAuditEvent a
 WHERE a.Comment LIKE '%logged in%' AND cast(a.date as date) >= cast(MinDate as date)
 GROUP BY a.CreatedBy

--- a/LDK/resources/queries/core/SiteUsagePerGroup.sql
+++ b/LDK/resources/queries/core/SiteUsagePerGroup.sql
@@ -23,8 +23,8 @@ a.EventType
 FROM core.groups g
 
 LEFT JOIN core.Members m ON (g.UserId = m.GroupId.UserId)
-LEFT JOIN "/".auditlog.audit a
-ON (a.CreatedBy.UserId = m.UserId.UserId AND a.EventType = 'UserAuditEvent' AND a.Comment LIKE '%logged in%')
+LEFT JOIN "/".auditlog.UserAuditEvent a
+ON (a.CreatedBy.UserId = m.UserId.UserId AND a.Comment LIKE '%logged in%')
 
 WHERE g.Name IS NOT NULL
 AND g.Name != ''


### PR DESCRIPTION
#### Rationale
EHR tests have been failing after the deprecation of the legacy "audit union" table because these usage queries still use it. Switching them to query the provisioned UserAuditEvent table directly is more straightforward and likely more efficient.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6892