### PR TITLE
Fix usage queries to reference Created (not Date)

### DIFF
--- a/LDK/resources/queries/core/DistinctUsersByMonth.sql
+++ b/LDK/resources/queries/core/DistinctUsersByMonth.sql
@@ -24,15 +24,15 @@ from (
 
 SELECT
 
-year(a.date) as year,
-month(a.date) as month,
+year(a.Created) as year,
+month(a.Created) as month,
 a.CreatedBy.DisplayName as user
 
 FROM "/".auditlog.UserAuditEvent a
 
 WHERE a.Comment LIKE '%logged in%'
 
-GROUP BY year(a.date), month(a.date), a.CreatedBy.DisplayName
+GROUP BY year(a.Created), month(a.Created), a.CreatedBy.DisplayName
 
 ) a
 

--- a/LDK/resources/queries/core/SiteUsageByDay.sql
+++ b/LDK/resources/queries/core/SiteUsageByDay.sql
@@ -15,19 +15,19 @@
  */
 SELECT
 
-cast(a.date as date) as date,
+cast(a.Created as date) as Date,
 CASE
-  WHEN dayofweek(cast(a.date as date)) = 1 THEN 'Sunday'
-  WHEN dayofweek(cast(a.date as date)) = 2 THEN 'Monday'
-  WHEN dayofweek(cast(a.date as date)) = 3 THEN 'Tuesday'
-  WHEN dayofweek(cast(a.date as date)) = 4 THEN 'Wednesday'
-  WHEN dayofweek(cast(a.date as date)) = 5 THEN 'Thursday'
-  WHEN dayofweek(cast(a.date as date)) = 6 THEN 'Friday'
-  WHEN dayofweek(cast(a.date as date)) = 7 THEN 'Saturday'
+    WHEN dayofweek(cast(a.Created as date)) = 1 THEN 'Sunday'
+    WHEN dayofweek(cast(a.Created as date)) = 2 THEN 'Monday'
+    WHEN dayofweek(cast(a.Created as date)) = 3 THEN 'Tuesday'
+    WHEN dayofweek(cast(a.Created as date)) = 4 THEN 'Wednesday'
+    WHEN dayofweek(cast(a.Created as date)) = 5 THEN 'Thursday'
+    WHEN dayofweek(cast(a.Created as date)) = 6 THEN 'Friday'
+    WHEN dayofweek(cast(a.Created as date)) = 7 THEN 'Saturday'
 END as dayOfWeek,
 count(*) AS Logins
 
 FROM "/".auditlog.UserAuditEvent a
 
 WHERE a.Comment LIKE '%logged in%'
-GROUP BY cast(a.date as date)
+GROUP BY cast(a.Created as date)

--- a/LDK/resources/queries/core/SiteUsageByHour.sql
+++ b/LDK/resources/queries/core/SiteUsageByHour.sql
@@ -16,11 +16,11 @@
 SELECT
 
 
-hour(a.date) as Hour,
+hour(a.Created) as Hour,
 count(*) AS Visits
 
 FROM "/".auditlog.UserAuditEvent a
 
 WHERE a.Comment LIKE '%logged in%'
 
-GROUP BY hour(a.date)
+GROUP BY hour(a.Created)

--- a/LDK/resources/queries/core/SiteUsageByMonth.sql
+++ b/LDK/resources/queries/core/SiteUsageByMonth.sql
@@ -15,9 +15,9 @@
  */
 SELECT
 
-year(a.date) as year,
-month(a.date) as month,
-cast(cast(year(a.date) as varchar) || '-' || cast(month(a.date) as varchar) || '-01' as DATE) as date,
+year(a.Created) as year,
+month(a.Created) as month,
+cast(cast(year(a.Created) as varchar) || '-' || cast(month(a.Created) as varchar) || '-01' as DATE) as date,
 count(*) AS Logins
 
 FROM "/".auditlog.UserAuditEvent a
@@ -25,4 +25,4 @@ FROM "/".auditlog.UserAuditEvent a
 
 WHERE a.Comment LIKE '%logged in%'
 
-GROUP BY year(a.date), month(a.date)
+GROUP BY year(a.Created), month(a.Created)

--- a/LDK/resources/queries/core/SiteUsageByUser.sql
+++ b/LDK/resources/queries/core/SiteUsageByUser.sql
@@ -17,7 +17,7 @@ PARAMETERS(MinDate TIMESTAMP)
 
 SELECT
 a.CreatedBy,
-COUNT(a.Date) AS LogInCount
+COUNT(a.Created) AS LogInCount
 FROM "/".auditlog.UserAuditEvent a
-WHERE a.Comment LIKE '%logged in%' AND cast(a.date as date) >= cast(MinDate as date)
+WHERE a.Comment LIKE '%logged in%' AND cast(a.Created as date) >= cast(MinDate as date)
 GROUP BY a.CreatedBy

--- a/LDK/resources/queries/core/SiteUsagePerGroup.sql
+++ b/LDK/resources/queries/core/SiteUsagePerGroup.sql
@@ -17,7 +17,7 @@ SELECT
 
 m.UserId,
 g.Name AS GroupName,
-a.Date,
+a.Created AS Date,
 a.EventType
 
 FROM core.groups g
@@ -28,4 +28,4 @@ ON (a.CreatedBy.UserId = m.UserId.UserId AND a.Comment LIKE '%logged in%')
 
 WHERE g.Name IS NOT NULL
 AND g.Name != ''
-AND a.Date IS NOT NULL
+AND a.Created IS NOT NULL


### PR DESCRIPTION
#### Rationale
Fix query validation during folder import in ONPRC tests. "Date" is no longer a column in audit event tables.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6903