### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
+++ b/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
@@ -494,7 +494,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
                     Date d = dateFormat.parse(expectations[idx]);
                     assertEquals("Incorrect value for: " + col + " on row " + i, d, serverVal);
                 }
-                else if ((serverVal instanceof Integer || serverVal instanceof Double))
+                else if ((serverVal instanceof Integer || serverVal instanceof Long || serverVal instanceof Double))
                 {
                     double d = Double.parseDouble(expectations[idx]);
                     assertEquals("Incorrect value for: " + col + " on row " + i, d, Double.parseDouble(serverVal.toString()), DELTA);

--- a/laboratory/api-src/org/labkey/api/laboratory/LaboratoryService.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/LaboratoryService.java
@@ -76,7 +76,7 @@ abstract public class LaboratoryService
 
     abstract public Set<AssayDataProvider> getRegisteredAssayProviders();
 
-    abstract public AssayDataProvider getDataProviderForAssay(int protocolId);
+    abstract public AssayDataProvider getDataProviderForAssay(long protocolId);
 
     abstract public AssayDataProvider getDataProviderForAssay(AssayProvider ap);
 

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/AbstractAssayDataProvider.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/AbstractAssayDataProvider.java
@@ -166,7 +166,7 @@ abstract public class AbstractAssayDataProvider extends AbstractDataProvider imp
     }
 
     @Override
-    public String getDefaultImportMethodName(Container c, User u, int protocolId)
+    public String getDefaultImportMethodName(Container c, User u, long protocolId)
     {
         Container targetContainer = c.isWorkbook() ? c.getParent() : c;
         Map<String, String> props = PropertyManager.getProperties(targetContainer, PROPERTY_CATEGORY);
@@ -176,7 +176,7 @@ abstract public class AbstractAssayDataProvider extends AbstractDataProvider imp
             return _importMethods.isEmpty() ?  null : _importMethods.iterator().next().getName();
     }
 
-    private String getDefaultMethodPropertyKey(int protocolId)
+    private String getDefaultMethodPropertyKey(long protocolId)
     {
         return getKey() + "||" + protocolId;
     }

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/AssayDataProvider.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/AssayDataProvider.java
@@ -55,7 +55,7 @@ public interface AssayDataProvider extends DataProvider
 
     AssayImportMethod getImportMethodByName(String methodName);
 
-    String getDefaultImportMethodName(Container c, User u, int protocolId);
+    String getDefaultImportMethodName(Container c, User u, long protocolId);
 
     boolean isModuleEnabled(Container c);
 }

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -462,7 +462,7 @@ public class DefaultAssayParser implements AssayParser
         errors.confirmNoErrors();
     }
 
-    protected void saveTemplate(ViewContext ctx, int templateId, int runId) throws BatchValidationException
+    protected void saveTemplate(ViewContext ctx, int templateId, long runId) throws BatchValidationException
     {
         try
         {

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/PivotingAssayParser.java
@@ -18,6 +18,7 @@ package org.labkey.api.laboratory.assay;
 import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.query.BatchValidationException;
@@ -27,7 +28,6 @@ import org.labkey.api.util.Pair;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -122,7 +122,7 @@ public class PivotingAssayParser extends DefaultAssayParser
      */
     private Map<Integer, String> inspectHeader(List<String> header, ImportContext context) throws BatchValidationException
     {
-        Map<Integer, String> resultMap = new HashMap<>();
+        Map<Integer, String> resultMap = new IntHashMap<>();
         Map<String, String> allowable = new CaseInsensitiveHashMap<>();
         BatchValidationException errors = new BatchValidationException();
 

--- a/laboratory/api-src/org/labkey/api/laboratory/query/ContainerIncrementingTable.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/query/ContainerIncrementingTable.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+
 /**
  * User: bimber
  * Date: 3/12/13
@@ -153,6 +155,8 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
             return null;
         else if (value instanceof Integer)
             return (Integer)value;
+        else if (value instanceof Long)
+            return asInteger(value);
         else if (value instanceof Double)
             return ((Double)value).intValue();
         try
@@ -326,9 +330,9 @@ public class ContainerIncrementingTable extends SimpleUserSchema.SimpleTable
                         Object selfAssignedId = it.getInputColumnValue(inputColMap.get(_incrementingCol));
                         if (selfAssignedId != null)
                         {
-                            if (selfAssignedId instanceof Integer)
+                            if (selfAssignedId instanceof Integer || selfAssignedId instanceof Long)
                             {
-                                rowId = (Integer)selfAssignedId;
+                                rowId = asInteger(selfAssignedId);
 
                                 if (idGen.hasRowWithId(c, rowId))
                                     _context.getErrors().addRowError(new ValidationException("A record is already present with ID: " + rowId));

--- a/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryServiceImpl.java
@@ -171,7 +171,7 @@ public class LaboratoryServiceImpl extends LaboratoryService
     }
 
     @Override
-    public AssayDataProvider getDataProviderForAssay(int protocolId)
+    public AssayDataProvider getDataProviderForAssay(long protocolId)
     {
         ExpProtocol protocol = ExperimentService.get().getExpProtocol(protocolId);
         if (protocol == null)

--- a/laboratory/src/org/labkey/laboratory/assay/RunUploadContext.java
+++ b/laboratory/src/org/labkey/laboratory/assay/RunUploadContext.java
@@ -196,7 +196,7 @@ public class RunUploadContext<ProviderType extends AssayProvider> implements Ass
      * The RowId for the run that is being deleted and reuploaded, or null if this is a new run
      */
     @Override
-    public Integer getReRunId()
+    public Long getReRunId()
     {
         return null;
     }


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->