### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
+++ b/LDK/test/src/org/labkey/test/tests/external/labModules/LabModulesTest.java
@@ -75,6 +75,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 /**
  * Contains a series of tests designed to test the UI in the laboratory module.
@@ -634,7 +635,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         goToProjectHome();
 
         //verify import not visible to reader
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         _helper.goToLabHome();
 
         waitForElement(LabModuleHelper.getNavPanelRow("Sequence:"), WAIT_FOR_PAGE);
@@ -1216,7 +1217,7 @@ public class LabModulesTest extends BaseWebDriverTest implements AdvancedSqlTest
         //verify settings hidden for readers
         Locator settings = _helper.toolIcon("Settings");
         assertElementPresent(settings);
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         _helper.goToLabHome();
         assertElementNotPresent(settings);
         stopImpersonatingRole();


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them