### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/LDK/src/org/labkey/ldk/LDKModule.java
+++ b/LDK/src/org/labkey/ldk/LDKModule.java
@@ -150,7 +150,7 @@ public class LDKModule extends ExtendedSimpleModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(LookupSetTable.TestCase.class);
     }

--- a/laboratory/src/org/labkey/laboratory/LaboratoryModule.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryModule.java
@@ -235,7 +235,7 @@ public class LaboratoryModule extends ExtendedSimpleModule
     }
 
     @Override
-    public @NotNull Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return PageFlowUtil.set(WorkbookTestCase.class);
     }


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.