### PR TITLE
Don't pass intrinsic types to convert() (e.g. int.class)

### DIFF
--- a/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
@@ -320,7 +320,7 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
             ColumnInfo pkCol = getColumn(FieldKey.fromString(_pseudoPk));
             try
             {
-                key = ConvertHelper.convert(key, pkCol.getJavaClass());
+                key = pkCol.convert(key);
             }
             catch (ConversionException e)
             {

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -258,7 +258,7 @@ public class DefaultAssayParser implements AssayParser
 
                     try
                     {
-                        ConvertHelper.convert(row.get(name), pd.getJavaClass());
+                        pd.convert(row.get(name));
                     }
                     catch (ConversionException e)
                     {


### PR DESCRIPTION
#### Rationale
Avoid calling ConvertHelper.convert() with a primitive type

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
