### PR TITLE
Improve nullability treatment for PageFlowUtil.urlProvider()

### DIFF
--- a/LDK/api-src/org/labkey/api/ldk/notification/AbstractNotification.java
+++ b/LDK/api-src/org/labkey/api/ldk/notification/AbstractNotification.java
@@ -45,10 +45,6 @@ abstract public class AbstractNotification implements Notification
     public AbstractNotification(Module owner)
     {
         _owner = owner;
-
-        // AbstractNotifications must be constructed after QueryUrls has been registered, typically in startup() or
-        // doStartupAfterSpringConfig()
-        assert _queryUrls != null;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
The vast majority of callers of PageFlowUtil.urlProvider() are in the module that supplies the provider, or in a module that has a hard dependency on the supplying module. We can eliminate thousands of warnings in the code about null return values by differentiating between nullable and non-nullable use cases.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/7618

#### Changes
- Split `PageFlowUtil.urlProvider()` (throws a clear exception instead of returning null) and `PageFlowUtil.urlProviderOptional()` (may return null)
- Update select callers to eliminate their own null special-casing