### PR TITLE
Scope laboratory assay protocol lookups to the request container

### DIFF
--- a/laboratory/src/org/labkey/laboratory/LaboratoryController.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryController.java
@@ -646,8 +646,11 @@ public class LaboratoryController extends SpringActionController
                         throw new UploadException("No Assay Id Provided", HttpServletResponse.SC_BAD_REQUEST);
                     }
 
+                    // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
+                    // scope for this container before using it; otherwise the same generic message is returned whether the
+                    // row id is unknown or simply belongs to a container the user cannot read.
                     ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getLabkeyAssayId());
-                    if (protocol == null)
+                    if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                     {
                         throw new UploadException("Unable to find assay protocol with Id: " + form.getLabkeyAssayId(), HttpServletResponse.SC_BAD_REQUEST);
                     }
@@ -935,8 +938,11 @@ public class LaboratoryController extends SpringActionController
             {
                 JSONObject json = new JSONObject(form.getJson());
 
+                // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
+                // scope for this container before saving a template against it. The same generic message is returned
+                // whether the row id is unknown or belongs to a container the user cannot read.
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getProtocolId());
-                if (protocol == null)
+                if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                 {
                     errors.reject(ERROR_MSG, "Unknown assay: " + form.getProtocolId());
                     return null;
@@ -1062,8 +1068,11 @@ public class LaboratoryController extends SpringActionController
                     return;
                 }
 
+                // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
+                // scope for this container before generating a template against it. The same generic message is returned
+                // whether the row id is unknown or belongs to a container the user cannot read.
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getLabkeyAssayId());
-                if (protocol == null)
+                if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                 {
                     throw new AbstractFileUploadAction.UploadException("Unable to find assay protocol with Id: " + form.getLabkeyAssayId(), HttpServletResponse.SC_BAD_REQUEST);
                 }
@@ -1513,8 +1522,11 @@ public class LaboratoryController extends SpringActionController
                 return new ApiSimpleResponse(results);
             }
 
+            // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in scope
+            // for this container before returning its import columns. The same generic message is returned whether the
+            // row id is unknown or belongs to a container the user cannot read.
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getProtocol());
-            if (protocol == null)
+            if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
             {
                 errors.reject(ERROR_MSG, "Protocol not found: " + form.getProtocol());
                 return new ApiSimpleResponse(results);
@@ -1877,8 +1889,19 @@ public class LaboratoryController extends SpringActionController
             List<ExpProtocol> protocols = new ArrayList<>();
             if (form.getAssayId() != null)
             {
-                protocols.add(ExperimentService.get().getExpProtocol(form.getAssayId()));
-                ap = AssayService.get().getProvider(protocols.get(0));
+                ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getAssayId());
+                // getExpProtocol() is a global row-id lookup with no container scoping. Verify the requested protocol is
+                // actually in scope for this container before using or echoing its metadata, otherwise a user with read
+                // access to any one folder could enumerate arbitrary row ids and harvest assay names and container paths
+                // from folders they cannot read. Use the same generic message whether or not the row id exists so the
+                // response is not an existence oracle for protocols in other containers.
+                if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
+                {
+                    errors.reject(ERROR_MSG, "Unknown assay: " + form.getAssayId());
+                    return null;
+                }
+                protocols.add(protocol);
+                ap = AssayService.get().getProvider(protocol);
             }
             else if (form.getAssayType() != null)
             {

--- a/laboratory/src/org/labkey/laboratory/LaboratoryController.java
+++ b/laboratory/src/org/labkey/laboratory/LaboratoryController.java
@@ -646,9 +646,7 @@ public class LaboratoryController extends SpringActionController
                         throw new UploadException("No Assay Id Provided", HttpServletResponse.SC_BAD_REQUEST);
                     }
 
-                    // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
-                    // scope for this container before using it; otherwise the same generic message is returned whether the
-                    // row id is unknown or simply belongs to a container the user cannot read.
+                    // getExpProtocol() is unscoped, so verify the protocol is in scope for this container before using it.
                     ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getLabkeyAssayId());
                     if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                     {
@@ -938,9 +936,7 @@ public class LaboratoryController extends SpringActionController
             {
                 JSONObject json = new JSONObject(form.getJson());
 
-                // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
-                // scope for this container before saving a template against it. The same generic message is returned
-                // whether the row id is unknown or belongs to a container the user cannot read.
+                // getExpProtocol() is unscoped, so verify the protocol is in scope for this container before saving a template against it.
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getProtocolId());
                 if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                 {
@@ -1068,9 +1064,7 @@ public class LaboratoryController extends SpringActionController
                     return;
                 }
 
-                // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in
-                // scope for this container before generating a template against it. The same generic message is returned
-                // whether the row id is unknown or belongs to a container the user cannot read.
+                // getExpProtocol() is unscoped, so verify the protocol is in scope for this container before generating a template against it.
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getLabkeyAssayId());
                 if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                 {
@@ -1522,9 +1516,7 @@ public class LaboratoryController extends SpringActionController
                 return new ApiSimpleResponse(results);
             }
 
-            // getExpProtocol() is a global row-id lookup with no container scoping, so confirm the protocol is in scope
-            // for this container before returning its import columns. The same generic message is returned whether the
-            // row id is unknown or belongs to a container the user cannot read.
+            // getExpProtocol() is unscoped, so verify the protocol is in scope for this container before returning its import columns.
             ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getProtocol());
             if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
             {
@@ -1890,11 +1882,8 @@ public class LaboratoryController extends SpringActionController
             if (form.getAssayId() != null)
             {
                 ExpProtocol protocol = ExperimentService.get().getExpProtocol(form.getAssayId());
-                // getExpProtocol() is a global row-id lookup with no container scoping. Verify the requested protocol is
-                // actually in scope for this container before using or echoing its metadata, otherwise a user with read
-                // access to any one folder could enumerate arbitrary row ids and harvest assay names and container paths
-                // from folders they cannot read. Use the same generic message whether or not the row id exists so the
-                // response is not an existence oracle for protocols in other containers.
+                // getExpProtocol() is unscoped, so verify the protocol is in scope before echoing its metadata; otherwise a user
+                // could enumerate arbitrary row ids and harvest assay names and container paths from folders they cannot read.
                 if (protocol == null || !AssayService.get().getAssayProtocols(getContainer()).contains(protocol))
                 {
                     errors.reject(ERROR_MSG, "Unknown assay: " + form.getAssayId());


### PR DESCRIPTION
## Rationale

`GetImportMethodsAction` and four sibling actions in `LaboratoryController` looked up assay protocols by row id via `ExperimentService.getExpProtocol(int)`, an unscoped global primary-key lookup. Because these actions are guarded only by container-level permissions, a user with read access to any single folder could supply an arbitrary protocol row id and have the server operate on a protocol defined in a folder they cannot read. `GetImportMethodsAction` additionally echoed the protocol's name, container, and container path back in its response, allowing cross-container enumeration of assay design names and folder paths (an IDOR / information-disclosure issue). The unchecked lookup in `GetImportMethodsAction` could also NPE on a non-existent row id.

## Related Pull Requests

None.

## Changes

- Each protocol lookup now verifies the protocol is in scope for the request container via `AssayService.getAssayProtocols(getContainer())` before use, covering `GetImportMethodsAction`, `ProcessAssayDataAction`, `SaveTemplateAction`, `CreateTemplateAction`, and `GetAssayImportHeadersAction`.
- The scope check is folded into each existing null guard, returning the same generic not-found message whether the row id is unknown or simply out of scope, so the response is not an existence oracle.
- Legitimate same-container callers (e.g. `Laboratory.Utils.getAssayDetails` from the assay import/template panels) are unaffected, since they always pass an in-scope protocol.
