### PR TITLE
Escape HTML in LDKController to prevent XSS

### DIFF
--- a/LDK/src/org/labkey/ldk/LDKController.java
+++ b/LDK/src/org/labkey/ldk/LDKController.java
@@ -92,6 +92,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class LDKController extends SpringActionController
 {
@@ -439,9 +440,9 @@ public class LDKController extends SpringActionController
             List<String> messages = service.validateContainerScopedTables(false);
 
             String sb = "This page is designed to inspect all registered container scoped tables and report any tables with duplicate keys in the same container.  This should be enforced by the user schema; however, direct DB inserts will bypass this check.<p>" +
-                    StringUtils.join(messages, "<br>");
+                    messages.stream().map(PageFlowUtil::filter).collect(Collectors.joining("<br>"));
 
-            return new HtmlView(HtmlString.of(sb));
+            return new HtmlView(HtmlString.unsafe(sb));
         }
 
         @Override
@@ -912,7 +913,7 @@ public class LDKController extends SpringActionController
                     }
                     catch (URISyntaxException e)
                     {
-                        return new HtmlView(HtmlString.unsafe("Invalid redirect URL set: " + urlString));
+                        return new HtmlView(HtmlString.of("Invalid redirect URL set: " + urlString));
                     }
                 }
             }


### PR DESCRIPTION
## Rationale

Two spots in LDKController rendered untrusted content as raw HTML. The container-scoped-table inspection view is a correction to a previous security fix (#268): the HTMLView cleanup there wrapped the whole string in HtmlString.of, which escaped the literal <br>/<p> markup too — safe, but it broke the intended formatting. This escapes only the dynamic validation messages (which can contain arbitrary content from direct DB inserts that bypass the user schema) while preserving the markup. The invalid-redirect error message separately echoed the user-supplied URL via HtmlString.unsafe, so it is now escaped.

## Related Pull Requests

- #268

## Changes

- Container-scoped-table inspection view: escape each validation message with PageFlowUtil.filter before joining with <br>, then wrap the assembled markup in HtmlString.unsafe — fixing the over-escaping introduced by #268 while keeping the output safe.
- Invalid-redirect error message: switch the user-supplied URL from HtmlString.unsafe to HtmlString.of so it is escaped.