### PR TITLE
Scope laboratory assay run template lookups to the appropriate container

### DIFF
--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -463,21 +463,29 @@ public class DefaultAssayParser implements AssayParser
         errors.confirmNoErrors();
     }
 
+    /**
+     * Returns the set of container ids in which an assay run template for a request in the given container may
+     * legitimately live: the container itself, plus its parent when the request runs in a workbook (mirroring the
+     * run-template picker, which sources templates from Laboratory.Utils.getQueryContainerPath). Used to scope
+     * assay_run_templates lookups to the request's folder tree without reaching an unrelated container.
+     */
+    public static List<String> getTemplateContainerIds(Container c)
+    {
+        List<String> ids = new ArrayList<>();
+        ids.add(c.getId());
+        if (c.isWorkbook())
+            ids.add(c.getParent().getId());
+        return ids;
+    }
+
     protected void saveTemplate(ViewContext ctx, int templateId, int runId) throws BatchValidationException
     {
         try
         {
-            // The template may live in this container, or its parent when importing from a workbook
-            // (the picker sources templates from getQueryContainerPath). Scope to that set, never beyond it.
-            List<String> templateContainers = new ArrayList<>();
-            templateContainers.add(_container.getId());
-            if (_container.isWorkbook())
-                templateContainers.add(_container.getParent().getId());
-
             //validate the template exists in (or above) this container
             TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
             SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-            filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
+            filter.addCondition(FieldKey.fromString("container"), getTemplateContainerIds(_container), CompareType.IN);
             TableSelector ts = new TableSelector(ti, filter, null);
             if (ts.getRowCount() == 0)
             {
@@ -594,15 +602,10 @@ public class DefaultAssayParser implements AssayParser
         if (templateId == null)
             return ret;
 
-        List<String> templateContainers = new ArrayList<>();
-        templateContainers.add(_container.getId());
-        if (_container.isWorkbook())
-            templateContainers.add(_container.getParent().getId());
-
         TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-        filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
+        filter.addCondition(FieldKey.fromString("container"), getTemplateContainerIds(_container), CompareType.IN);
         TableSelector ts = new TableSelector(ti, filter, null);
         Map<String, Object>[] maps = ts.getMapArray();
         if (maps.length == 0)

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -26,6 +26,7 @@ import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSchema;
@@ -466,10 +467,17 @@ public class DefaultAssayParser implements AssayParser
     {
         try
         {
-            //validate the template exists in this container
+            // The template may live in this container, or its parent when importing from a workbook
+            // (the picker sources templates from getQueryContainerPath). Scope to that set, never beyond it.
+            List<String> templateContainers = new ArrayList<>();
+            templateContainers.add(_container.getId());
+            if (_container.isWorkbook())
+                templateContainers.add(_container.getParent().getId());
+
+            //validate the template exists in (or above) this container
             TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
             SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-            filter.addCondition(FieldKey.fromString("container"), _container);
+            filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
             TableSelector ts = new TableSelector(ti, filter, null);
             if (ts.getRowCount() == 0)
             {
@@ -586,10 +594,15 @@ public class DefaultAssayParser implements AssayParser
         if (templateId == null)
             return ret;
 
+        List<String> templateContainers = new ArrayList<>();
+        templateContainers.add(_container.getId());
+        if (_container.isWorkbook())
+            templateContainers.add(_container.getParent().getId());
+
         TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-        filter.addCondition(FieldKey.fromString("container"), _container);
+        filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
         TableSelector ts = new TableSelector(ti, filter, null);
         Map<String, Object>[] maps = ts.getMapArray();
         if (maps.length == 0)

--- a/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
+++ b/laboratory/api-src/org/labkey/api/laboratory/assay/DefaultAssayParser.java
@@ -466,9 +466,11 @@ public class DefaultAssayParser implements AssayParser
     {
         try
         {
-            //validate the template exists
+            //validate the template exists in this container
             TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
-            TableSelector ts = new TableSelector(ti, new SimpleFilter(FieldKey.fromString("rowid"), templateId), null);
+            SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
+            filter.addCondition(FieldKey.fromString("container"), _container);
+            TableSelector ts = new TableSelector(ti, filter, null);
             if (ts.getRowCount() == 0)
             {
                 throw new BatchValidationException(Collections.singletonList(new ValidationException("Unknown template: " + templateId)), null);
@@ -586,7 +588,9 @@ public class DefaultAssayParser implements AssayParser
 
         TableInfo ti = DbSchema.get("laboratory").getTable("assay_run_templates");
 
-        TableSelector ts = new TableSelector(ti, new SimpleFilter(FieldKey.fromString("rowid"), templateId), null);
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
+        filter.addCondition(FieldKey.fromString("container"), _container);
+        TableSelector ts = new TableSelector(ti, filter, null);
         Map<String, Object>[] maps = ts.getMapArray();
         if (maps.length == 0)
         {

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -33,6 +33,7 @@ import org.labkey.api.collections.CollectionUtils;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.RuntimeSQLException;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TSVMapWriter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
@@ -51,6 +52,7 @@ import org.labkey.api.laboratory.LaboratoryService;
 import org.labkey.api.laboratory.assay.AssayDataProvider;
 import org.labkey.api.laboratory.assay.AssayImportMethod;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
@@ -139,6 +141,15 @@ public class AssayHelper
             }
             else
             {
+                // Table.update operates by global PK, so verify the existing template lives in this container before updating it
+                SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
+                filter.addCondition(FieldKey.fromString("container"), c);
+                if (!new TableSelector(ti, filter, null).exists())
+                {
+                    errors.addRowError(new ValidationException("Unknown template: " + templateId));
+                    throw errors;
+                }
+
                 row.put("rowid", templateId);
                 row = Table.update(u, ti, row, templateId);
             }

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -30,6 +30,7 @@ import org.labkey.api.assay.AssayService;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CollectionUtils;
+import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.RuntimeSQLException;
@@ -133,17 +134,23 @@ public class AssayHelper
             row.put("title", title);
             row.put("importMethod", importMethod);
             row.put("json", json.toString());
-            row.put("container", c.getId());
 
             if (templateId == null)
             {
+                row.put("container", c.getId());
                 row = Table.insert(u, ti, row);
             }
             else
             {
-                // Table.update operates by global PK, so verify the existing template lives in this container before updating it
+                // Table.update operates by global PK; verify the template is reachable from this container
+                // (here, or the parent when in a workbook) before updating, and leave its container unchanged.
+                List<String> templateContainers = new ArrayList<>();
+                templateContainers.add(c.getId());
+                if (c.isWorkbook())
+                    templateContainers.add(c.getParent().getId());
+
                 SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-                filter.addCondition(FieldKey.fromString("container"), c);
+                filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
                 if (!new TableSelector(ti, filter, null).exists())
                 {
                     errors.addRowError(new ValidationException("Unknown template: " + templateId));
@@ -151,7 +158,7 @@ public class AssayHelper
                 }
 
                 row.put("rowid", templateId);
-                row = Table.update(u, ti, row, templateId);
+                row = Table.update(u, ti, row, templateId);  // "container" intentionally absent -> not moved
             }
 
             return row;

--- a/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
+++ b/laboratory/src/org/labkey/laboratory/assay/AssayHelper.java
@@ -52,6 +52,7 @@ import org.labkey.api.exp.property.DomainProperty;
 import org.labkey.api.laboratory.LaboratoryService;
 import org.labkey.api.laboratory.assay.AssayDataProvider;
 import org.labkey.api.laboratory.assay.AssayImportMethod;
+import org.labkey.api.laboratory.assay.DefaultAssayParser;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.ValidationException;
@@ -144,13 +145,8 @@ public class AssayHelper
             {
                 // Table.update operates by global PK; verify the template is reachable from this container
                 // (here, or the parent when in a workbook) before updating, and leave its container unchanged.
-                List<String> templateContainers = new ArrayList<>();
-                templateContainers.add(c.getId());
-                if (c.isWorkbook())
-                    templateContainers.add(c.getParent().getId());
-
                 SimpleFilter filter = new SimpleFilter(FieldKey.fromString("rowid"), templateId);
-                filter.addCondition(FieldKey.fromString("container"), templateContainers, CompareType.IN);
+                filter.addCondition(FieldKey.fromString("container"), DefaultAssayParser.getTemplateContainerIds(c), CompareType.IN);
                 if (!new TableSelector(ti, filter, null).exists())
                 {
                     errors.addRowError(new ValidationException("Unknown template: " + templateId));


### PR DESCRIPTION
## Rationale

The `assay_run_templates` lookups in `DefaultAssayParser.saveTemplate`, `DefaultAssayParser.getTemplateRowMap`, and `AssayHelper.saveTemplate` filtered only by `rowid`, which is the table's global primary key. Because `Table.update` also operates by global PK, a user could pass a `templateId` belonging to another container and have that foreign template read or updated (`runid`/`status`), bypassing container authorization. Each lookup is now scoped to the request's own folder tree: the request container, and additionally its parent when the request runs in a workbook, since a template referenced from a workbook import may reside in either the workbook or its parent (the run-template picker reaches up to the parent via `Laboratory.Utils.getQueryContainerPath`). This preserves the existing workbook import workflow while never reaching an unrelated container.

## Related Pull Requests

None.

## Changes

- Scope the three `assay_run_templates` lookups to the set `{ request container, its parent when a workbook }` via an `IN` filter, replacing the `rowid`-only filter.
- In `AssayHelper.saveTemplate`, set `container` only on insert and omit it from the update row so an existing parent-owned template is not moved into the workbook by `Table.update`.
- Extract the container-scoping rule into a shared `DefaultAssayParser.getTemplateContainerIds(Container)` helper used by all three call sites.