### PR TITLE
Fix LDK reader crash under ES2023 target of @labkey/api

### DIFF
--- a/LDK/resources/web/LDK/data/LabKeyStore.js
+++ b/LDK/resources/web/LDK/data/LabKeyStore.js
@@ -53,7 +53,7 @@ Ext4.define('LDK.data.proxy.ExtendedJsonReader', {
         if (data.metaData){
             Ext4.each(data.metaData.fields, function(field){
                 if (!field.name){
-                    var fk = new LABKEY.FieldKey.fromParts(field.fieldKey);
+                    var fk = LABKEY.FieldKey.fromParts(field.fieldKey);
                     field.name = fk.toString();
                 }
             }, this);


### PR DESCRIPTION
#### Rationale
Under the pre-ES2023 target of `@labkey/api`, TypeScript compiled `FieldKey.fromParts` to a plain function property. Regular functions in JS are constructable, and when you call one with `new` and the function explicitly returns an object, `new` just hands back that returned object — so `new LABKEY.FieldKey.fromParts(x)` and `LABKEY.FieldKey.fromParts(x)` produced the same value, and the misused `new` was redundant but harmless. Under ES2023, `FieldKey` emits as a native ES6 class and `fromParts` becomes a real class static method. Static methods on native ES6 classes can be called normally but are not constructors — invoking one with `new` throws `TypeError: … is not a constructor`.

The bad call sits in the `readRecords` override in `LabKeyStore.js`. When `new` throws, the reader aborts before finishing its setup, leaving downstream Ext stores unable to identify their records on submit. That's what broke the JHU_EHR and NIRC_EHR data-entry tests (https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrPostgres?branch=%3Cdefault%3E&buildTypeTab=overview#all-projects). However, this isn't a test-only fix, any Ext4 store whose reader chain resolves to LDK.data.proxy.ExtendedJsonReader - the default for LDK.data.LabKeyStore and everything extending it (EHR.data.DataEntryServerStore in particular) - hangs or fails on submit for real users whenever the query metadata carries a field without a name

#### Related Pull Requests
* Introduced by: https://github.com/LabKey/labkey-api-js/pull/219 — TypeScript target flipped to ES2023.
* Companion fix: https://github.com/LabKey/labkey-api-js/pull/221 — fixed a related ES2023 side effect that broke `LABKEY.*` runtime overrides. This particular PR handles another one affecting EHR data entry forms

#### Changes
* `LDK/resources/web/LDK/data/LabKeyStore.js`: drop the redundant `new` from the call to `LABKEY.FieldKey.fromParts(field.fieldKey)`. `fromParts` is a factory that already constructs and returns a `FieldKey`; no behavior change other than restoring compatibility with ES2023-compiled `@labkey/api`.