### PR TITLE
Allow inserts on ContainerScopedTable when pseudo-key is the real PK

### DIFF
--- a/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
+++ b/LDK/api-src/org/labkey/api/ldk/table/ContainerScopedTable.java
@@ -80,15 +80,25 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
     {
         super.init();
 
+        boolean realPkIsPseudoKey = false;
         for (String col : getRealTable().getPkColumnNames())
         {
             var existing = getMutableColumn(col);
             if (existing != null)
             {
-                existing.setKeyField(false);
-                existing.setUserEditable(false);
-                existing.setHidden(true);
                 _realPKs.add(col);
+                if (col.equalsIgnoreCase(_pseudoPk))
+                {
+                    // The pseudo-key is also the real PK (a natural key, like ehr_lookups.project_types.type),
+                    // so it must remain visible and editable for inserts to be possible
+                    realPkIsPseudoKey = true;
+                }
+                else
+                {
+                    existing.setKeyField(false);
+                    existing.setUserEditable(false);
+                    existing.setHidden(true);
+                }
             }
         }
 
@@ -96,6 +106,11 @@ public class ContainerScopedTable<SchemaType extends UserSchema> extends CustomP
         assert newKey != null;
 
         newKey.setKeyField(true);
+        if (realPkIsPseudoKey)
+        {
+            // Enterable on insert, but hidden from the update form
+            newKey.setShownInUpdateView(false);
+        }
         return this;
     }
 


### PR DESCRIPTION
## Rationale

`ContainerScopedTable.init()` hid and disabled every real PK column, assuming the real PK is always a surrogate key (e.g. an auto-incrementing rowid). When the pseudo-key is also the real PK (a natural key, like `ehr_lookups.project_types.type`), this made the key column hidden and non-editable, so it could not be entered through the single-row insert UI (API-based inserts were unaffected).

## Related Pull Requests

None.

## Changes

- Detect when the pseudo-key column is itself the real PK and leave it visible and editable so it can be entered in the single-row insert UI; other real PK columns are hidden and disabled as before.
- Editing the column remains unavailable in the UI: it is hidden from the update form via `setShownInUpdateView(false)`, so it is enterable on insert but not shown when editing.